### PR TITLE
fix: flaky python test for IFE process

### DIFF
--- a/plasma_framework/python_tests/setup.cfg
+++ b/plasma_framework/python_tests/setup.cfg
@@ -2,5 +2,5 @@
 license_file = LICENSE.txt
 
 [flake8]
-ignore = 
-	E501
+ignore =
+	E501, W503

--- a/plasma_framework/python_tests/testlang/testlang.py
+++ b/plasma_framework/python_tests/testlang/testlang.py
@@ -454,8 +454,9 @@ class TestingLanguage:
         if forward_time:
             self.forward_timestamp(forward_time)
 
-    def challenge_in_flight_exit_input_spent(self, in_flight_tx_id, spend_tx_id, key):
-        in_flight_tx = self.child_chain.get_transaction(in_flight_tx_id)
+    def challenge_in_flight_exit_input_spent(self, in_flight_tx_id, spend_tx_id, key, in_flight_tx=None):
+        if in_flight_tx is None:
+            in_flight_tx = self.child_chain.get_transaction(in_flight_tx_id)
         spend_tx = self.child_chain.get_transaction(spend_tx_id)
         (in_flight_tx_input_index, spend_tx_input_index) = self.find_shared_input(in_flight_tx, spend_tx)
         signature = spend_tx.signatures[spend_tx_input_index]

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
@@ -861,7 +861,7 @@ def test_should_not_allow_to_withdraw_from_non_canonical_and_already_spent_input
     6. Sb starts IFE for the steal tx
     7. Alice and Caroline both piggyback all inputs and outputs of both IFEs
     8. Alice challenge the IFE for steal tx non canonical and challenge the input already spent
-    9. Sb processes the exit. Alice should get her output exited from the swap tx. Caroline's ETH input should not be able to exit.
+    9. Sb processes the exit. Both Alice and Caroline should get the output funds from the swap tx but nothing from steal tx
     """
 
     alice, amount_token = testlang.accounts[1], 200

--- a/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
+++ b/plasma_framework/python_tests/tests/contracts/root_chain/test_process_exits.py
@@ -850,6 +850,7 @@ def test_should_not_allow_to_withdraw_outputs_from_two_ifes_marked_as_canonical_
     caroline_eth_balance = testlang.get_balance(caroline)
     assert caroline_eth_balance == caroline_eth_balance_before
 
+
 def test_should_not_allow_to_withdraw_from_non_canonical_and_already_spent_input_but_can_withdraw_from_canonical_tx_outputs(testlang, w3, plasma_framework, token):
     """
     1. Alice deposits some token
@@ -918,16 +919,16 @@ def test_should_not_allow_to_withdraw_from_non_canonical_and_already_spent_input
     caroline_eth_balance = testlang.get_balance(caroline)
     assert caroline_eth_balance == (
         caroline_eth_balance_before
-        + 3 * testlang.root_chain.piggybackBond() # 4 piggybacks, with 1 being challenged
+        + 3 * testlang.root_chain.piggybackBond()  # 4 piggybacks, with 1 being challenged
     )
 
     # alice exits with eth
     alice_eth_balance = testlang.get_balance(alice)
     assert alice_eth_balance == (
         alice_eth_balance_before
-        + amount_eth # get the ETH from exit output
-        + 2 * testlang.root_chain.piggybackBond() # get 2 piggybacks bonds back
-        + testlang.root_chain.inFlightExitBond() # get start IFE bond from challenge non-canonical
+        + amount_eth  # get the ETH from exit output
+        + 2 * testlang.root_chain.piggybackBond()  # get 2 piggybacks bonds back
+        + testlang.root_chain.inFlightExitBond()  # get start IFE bond from challenge non-canonical
     )
     # but she does not get token back
     alice_token_balance = token.balanceOf(alice.address)


### PR DESCRIPTION
### Note
The flaky python test setup was doomed to be flaky as there is no promise on the priority of 2 IFEs to be in the expected order of first come first serve. In fact the setup is more like broken where a non-canonical IFE should be challenged instead of processed as canonical. This PR change the test setup and rename the test to a non-canonical tx challenge scenario.

#### Side change
- ignore W503 standard for flake: https://www.flake8rules.com/rules/W503.html

see: https://github.com/omgnetwork/plasma-contracts/issues/606#issuecomment-678871977

fix: #606 