### PR TITLE
Deploy Contracts serially and enable CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,9 +383,13 @@ workflows:
             branches:
               only:
                 - v2.0.0
+                - souradeep/deploy_test
       - Deploy to Rinkeby with Gnosis and Vault:
+          requires:
+            - Deploy to Rinkeby
           filters:
             branches:
               only:
                 - v2.0.0
+                - souradeep/deploy_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,6 @@ workflows:
             branches:
               only:
                 - v2.0.0
-                - souradeep/deploy_test
       - Deploy to Rinkeby with Gnosis and Vault:
           requires:
             - Deploy to Rinkeby
@@ -391,5 +390,4 @@ workflows:
             branches:
               only:
                 - v2.0.0
-                - souradeep/deploy_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - v2.0.0
 
   Deployment checks:
     jobs:

--- a/.github/workflows/dispatch-sync-to-private.yml
+++ b/.github/workflows/dispatch-sync-to-private.yml
@@ -2,7 +2,7 @@ name: Dispatch sync event to plasma-contracts-private
 
 on:
   push:
-    branches: [master]
+    branches: [v2.0.0]
 
 jobs:
   dispatch-sync-event:

--- a/.github/workflows/sync-from-public-to-private.yml
+++ b/.github/workflows/sync-from-public-to-private.yml
@@ -27,7 +27,7 @@ jobs:
           # https://github.com/repo-sync/github-sync/blob/520596e97177727db1f2a1de14f4ded905624066/github-sync.sh#L23-L33
 
           readonly SOURCE_REPO="omgnetwork/plasma-contracts"
-          readonly SOURCE_BRANCH="master"
+          readonly SOURCE_BRANCH="v2.0.0"
           readonly DESTINATION_BRANCH="master"
 
           echo "Syncing ${DESTINATION_BRANCH} from branch ${SOURCE_BRANCH} of ${SOURCE_REPO}..."


### PR DESCRIPTION
#### Overview

Since, the same infura account is used for both the Rinkeby deployment workflows, only one of them successfully succeeds. This could be because of infura having trouble to handle nonce. Using a nonce tracker also doesn't solve the problem. So Deploying asynchronously