### PR TITLE
feat: safe block margin

### DIFF
--- a/plasma_framework/contracts/poc/fast_exits/Quasar.sol
+++ b/plasma_framework/contracts/poc/fast_exits/Quasar.sol
@@ -73,12 +73,12 @@ contract Quasar {
      * @param _bondValue bond to obtain tickets
     */
     constructor (
-      address plasmaFrameworkContract, 
-      address spendingConditionRegistryContract, 
-      address _quasarOwner, 
-      uint256 _safeBlockMargin, 
-      uint256 _waitingPeriod, 
-      uint256 _bondValue
+        address plasmaFrameworkContract, 
+        address spendingConditionRegistryContract, 
+        address _quasarOwner, 
+        uint256 _safeBlockMargin, 
+        uint256 _waitingPeriod, 
+        uint256 _bondValue
     ) public {
         plasmaFramework = PlasmaFramework(plasmaFrameworkContract);
         spendingConditionRegistry = SpendingConditionRegistry(spendingConditionRegistryContract);
@@ -94,9 +94,9 @@ contract Quasar {
      * @return  The latest safe block number
     */
     function getLatestSafeBlock() public view returns(uint256) {
-      uint256 childBlockInterval = plasmaFramework.childBlockInterval();
-      uint currentPlasmaBlock = plasmaFramework.nextChildBlock().sub(childBlockInterval);
-      return currentPlasmaBlock.sub(safeBlockMargin.mul(childBlockInterval));
+        uint256 childBlockInterval = plasmaFramework.childBlockInterval();
+        uint currentPlasmaBlock = plasmaFramework.nextChildBlock().sub(childBlockInterval);
+        return currentPlasmaBlock.sub(safeBlockMargin.mul(childBlockInterval));
     }
 
     ////////////////////////////////////////////	

--- a/plasma_framework/test/endToEndTests/QuasarExit.e2e.test.js
+++ b/plasma_framework/test/endToEndTests/QuasarExit.e2e.test.js
@@ -52,6 +52,10 @@ contract(
             await Promise.all([setupAccount(), deployStableContracts()]);
         });
 
+        const submitPlasmaBlock = async () => {
+            await this.framework.submitBlock(DUMMY_BLOCK_HASH, { from: authority });
+        };
+
         const setupContracts = async () => {
             this.framework = await PlasmaFramework.deployed();
             this.spendingConditionRegistry = await SpendingConditionRegistry.deployed();
@@ -65,7 +69,7 @@ contract(
 
             // Submit some blocks to have a safe block margin
             for (let i = 0; i < INITIAL_SAFE_BLOCK_MARGIN; i++) {
-                await submitPlasmaBlock();
+                await submitPlasmaBlock(); // eslint-disable-line no-await-in-loop
             }
         };
 
@@ -92,10 +96,6 @@ contract(
             this.merkleProofForDepositTx = this.merkleTreeForDepositTx.getInclusionProof(this.depositTx);
 
             return this.ethVault.deposit(this.depositTx, { from: alice, value: DEPOSIT_VALUE });
-        };
-
-        const submitPlasmaBlock = async () => {
-            await this.framework.submitBlock(DUMMY_BLOCK_HASH, { from: authority });
         };
 
         const aliceTransferEth = async (receiver, transferAmount) => {

--- a/plasma_framework/test/src/poc/fast_exits/Quasar.test.js
+++ b/plasma_framework/test/src/poc/fast_exits/Quasar.test.js
@@ -1,0 +1,101 @@
+const Quasar = artifacts.require('Quasar');
+const BlockController = artifacts.require('BlockControllerMock');
+const SpendingConditionMock = artifacts.require('SpendingConditionMock');
+const SpendingConditionRegistry = artifacts.require('SpendingConditionRegistry');
+
+const { BN, expectRevert, constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+const { TX_TYPE, OUTPUT_TYPE, DUMMY_INPUT_1 } = require('../../../helpers/constants.js');
+const { MerkleTree } = require('../../../helpers/merkle.js');
+const { buildUtxoPos } = require('../../../helpers/positions.js');
+const { PaymentTransactionOutput, PaymentTransaction } = require('../../../helpers/transaction.js');
+
+
+contract('Quasar', ([authority, quasarOwner, quasarMaintainer, alice]) => {
+    const CHILD_BLOCK_INTERVAL = 1000;
+    const MIN_EXIT_PERIOD = 10;
+    const INITIAL_IMMUNE_VAULTS = 1;
+    const SAFE_BLOCK_MARGIN = 10;
+    const WAITING_PERIOD = 3600;
+    const BOND_VALUE = 100;
+
+    const setupAllContracts = async () => {
+        this.plasmaFramework = await BlockController.new(
+            CHILD_BLOCK_INTERVAL,
+            MIN_EXIT_PERIOD,
+            INITIAL_IMMUNE_VAULTS,
+            authority,
+        );
+
+        // Submit some blocks to have a safe block margin
+        const DUMMY_BLOCK_HASH = web3.utils.sha3('dummy root');
+        for (let i = 0; i < SAFE_BLOCK_MARGIN; i++) {
+            await this.plasmaFramework.submitBlock(DUMMY_BLOCK_HASH, { from: authority });
+        }
+
+        this.spendingConditionRegistry = await SpendingConditionRegistry.new();
+        this.spendingCondition = await SpendingConditionMock.new();
+        // lets the spending condition pass by default
+        await this.spendingCondition.mockResult(true);
+        await this.spendingConditionRegistry.registerSpendingCondition(
+            OUTPUT_TYPE.PAYMENT, TX_TYPE.PAYMENT, this.spendingCondition.address,
+        );
+
+        this.quasar = await Quasar.new(
+            this.plasmaFramework.address,
+            this.spendingConditionRegistry.address,
+            quasarOwner,
+            SAFE_BLOCK_MARGIN,
+            WAITING_PERIOD,
+            BOND_VALUE,
+            { from: quasarMaintainer },
+        );
+    };
+
+    describe('deposit', () => {
+        beforeEach(setupAllContracts);
+
+        it('should set the safe block margin', async () => {
+            const testSafeBlockMargin = 57;
+            await this.quasar.setSafeBlockMargin(
+                testSafeBlockMargin,
+                { from: quasarMaintainer },
+            );
+
+            const safeBlockMargin = await this.quasar.safeBlockMargin();
+            expect(safeBlockMargin).to.be.bignumber.equal(new BN(testSafeBlockMargin));
+        });
+
+        it('should fail to set the safe block margin if not from quasarMaintainer', async () => {
+            await expectRevert(
+                this.quasar.setSafeBlockMargin(
+                    1,
+                    { from: alice },
+                ),
+                'Only the Quasar Maintainer can invoke this method',
+            );
+        });
+
+        it('should fail to accept an exit from an output younger than the safe block margin', async () => {
+            const dummyTx = '0x0';
+            const dummyProof = '0x0';
+
+            const nextPlasmaBlock = await this.plasmaFramework.nextChildBlock();
+            const youngBlockNum = nextPlasmaBlock - CHILD_BLOCK_INTERVAL;
+            const utxoPos = buildUtxoPos(youngBlockNum, 0, 0);
+
+            await expectRevert(
+                this.quasar.obtainTicket(
+                    utxoPos,
+                    dummyTx,
+                    dummyProof,
+                    {
+                        from: alice,
+                        value: BOND_VALUE,
+                    },
+                ),
+                'The UTXO is from a block later than the safe limit',
+            );
+        });
+    });
+});

--- a/plasma_framework/test/src/poc/fast_exits/Quasar.test.js
+++ b/plasma_framework/test/src/poc/fast_exits/Quasar.test.js
@@ -3,12 +3,10 @@ const BlockController = artifacts.require('BlockControllerMock');
 const SpendingConditionMock = artifacts.require('SpendingConditionMock');
 const SpendingConditionRegistry = artifacts.require('SpendingConditionRegistry');
 
-const { BN, expectRevert, constants } = require('openzeppelin-test-helpers');
+const { BN, expectRevert } = require('openzeppelin-test-helpers');
 const { expect } = require('chai');
-const { TX_TYPE, OUTPUT_TYPE, DUMMY_INPUT_1 } = require('../../../helpers/constants.js');
-const { MerkleTree } = require('../../../helpers/merkle.js');
+const { TX_TYPE, OUTPUT_TYPE } = require('../../../helpers/constants.js');
 const { buildUtxoPos } = require('../../../helpers/positions.js');
-const { PaymentTransactionOutput, PaymentTransaction } = require('../../../helpers/transaction.js');
 
 
 contract('Quasar', ([authority, quasarOwner, quasarMaintainer, alice]) => {
@@ -30,6 +28,7 @@ contract('Quasar', ([authority, quasarOwner, quasarMaintainer, alice]) => {
         // Submit some blocks to have a safe block margin
         const DUMMY_BLOCK_HASH = web3.utils.sha3('dummy root');
         for (let i = 0; i < SAFE_BLOCK_MARGIN; i++) {
+            // eslint-disable-next-line no-await-in-loop
             await this.plasmaFramework.submitBlock(DUMMY_BLOCK_HASH, { from: authority });
         }
 


### PR DESCRIPTION
Changes `safePlasmaBlockNum` to `safeBlockMargin` - the Quasar will not accept exits for outputs younger than the current plasma block minus `safeBlockMargin`.
