### PR TITLE
quasar: make ifeClaimData public

### DIFF
--- a/plasma_framework/contracts/poc/fast_exits/Quasar.sol
+++ b/plasma_framework/contracts/poc/fast_exits/Quasar.sol
@@ -64,7 +64,7 @@ contract Quasar is QuasarPool {
     }
 
     mapping (uint256 => Ticket) public ticketData;
-    mapping (uint256 => Claim) private ifeClaimData;
+    mapping (uint256 => Claim) public ifeClaimData;
 
     event NewTicketObtained(uint256 utxoPos);
     event IFEClaimSubmitted(uint256 utxoPos, uint160 exitId);


### PR DESCRIPTION
Making the ifeClaimData mapping in Quasar public so that the challenger can check if any IFEs are being claimed 