### PR TITLE
quasar: Add fee and returns to quasar pool

### DIFF
--- a/plasma_framework/contracts/mocks/poc/QuasarPoolMock.sol
+++ b/plasma_framework/contracts/mocks/poc/QuasarPoolMock.sol
@@ -1,0 +1,22 @@
+pragma solidity 0.5.11;
+pragma experimental ABIEncoderV2;
+
+import "../../poc/fast_exits/Quasar.sol";
+
+contract QuasarPoolMock is Quasar {
+
+    constructor (
+        address plasmaFrameworkContract, 
+        address spendingConditionRegistryContract, 
+        address _quasarOwner, 
+        uint256 _safeBlockMargin, 
+        uint256 _waitingPeriod, 
+        uint256 _bondValue
+    ) public Quasar(plasmaFrameworkContract, spendingConditionRegistryContract, _quasarOwner, _safeBlockMargin, _waitingPeriod, _bondValue) {
+    }
+
+    function utilizeQuasarPool(address token, uint256 amount) public payable {
+        utilize(token, amount);
+        tokenUsableCapacity[token] += msg.value;
+    }
+}

--- a/plasma_framework/contracts/poc/fast_exits/QToken.sol
+++ b/plasma_framework/contracts/poc/fast_exits/QToken.sol
@@ -5,7 +5,7 @@ import "../../src/utils/OnlyFromAddress.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 
-contract QToken is ERC20,ERC20Detailed,OnlyFromAddress {
+contract QToken is ERC20, ERC20Detailed, OnlyFromAddress {
 
     address public quasarContract;
 

--- a/plasma_framework/contracts/poc/fast_exits/QToken.sol
+++ b/plasma_framework/contracts/poc/fast_exits/QToken.sol
@@ -1,0 +1,33 @@
+pragma solidity 0.5.11;
+pragma experimental ABIEncoderV2;
+
+import "../../src/utils/OnlyFromAddress.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
+
+contract QToken is ERC20,ERC20Detailed,OnlyFromAddress {
+
+    address public quasarContract;
+
+    constructor(string memory name, string memory symbol, uint8 decimals, address owner) public ERC20Detailed(name, symbol, decimals) {
+        quasarContract = owner;
+    }
+
+    /**
+     * @dev Mint tokens for the address
+     * @param account the address
+     * @param amount the number of tokens to mint
+    */
+    function mint(address account, uint256 amount) external onlyFrom(quasarContract) {
+        _mint(account, amount);
+    }
+
+    /**
+     * @dev Burn specified tokens from the address
+     * @param account the address
+     * @param amount the number of tokens to burn
+    */
+    function burn(address account, uint256 amount) external onlyFrom(quasarContract) {
+        _burn(account, amount);
+    }
+}

--- a/plasma_framework/contracts/poc/fast_exits/QToken.sol
+++ b/plasma_framework/contracts/poc/fast_exits/QToken.sol
@@ -2,10 +2,11 @@ pragma solidity 0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "../../src/utils/OnlyFromAddress.sol";
+import "./interfaces/IQToken.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 
-contract QToken is ERC20, ERC20Detailed, OnlyFromAddress {
+contract QToken is IQToken, ERC20, ERC20Detailed, OnlyFromAddress {
 
     address public quasarContract;
 

--- a/plasma_framework/contracts/poc/fast_exits/Quasar.sol
+++ b/plasma_framework/contracts/poc/fast_exits/Quasar.sol
@@ -67,7 +67,7 @@ contract Quasar is QuasarPool {
     }
 
     mapping (uint256 => Ticket) public ticketData;
-    mapping (uint256 => Claim) private ifeClaimData;
+    mapping (uint256 => Claim) public ifeClaimData;
 
     event NewTicketObtained(uint256 utxoPos);
     event IFEClaimSubmitted(uint256 utxoPos, uint160 exitId);

--- a/plasma_framework/contracts/poc/fast_exits/Quasar.sol
+++ b/plasma_framework/contracts/poc/fast_exits/Quasar.sol
@@ -201,9 +201,7 @@ contract Quasar is QuasarPool {
 
         uint256 quasarFee = tokenData[outputData.token].quasarFee;
 
-        // can skip this check because tokenUsableCapacity confirms qToken exists
-        // require(tokenData[outputData.token].qTokenAddress != address(0), "QToken is not registered for the token");
-        require(outputData.amount > quasarFee, "Requested amount cannot be zero");
+        require(outputData.amount > quasarFee, "The UTXO isn't enough to cover the fee");
         uint256 reservedAmount = outputData.amount.sub(quasarFee);
         require(reservedAmount <= tokenUsableCapacity[outputData.token], "Requested amount exceeds the Usable Liqudity");
 

--- a/plasma_framework/contracts/poc/fast_exits/QuasarPool.sol
+++ b/plasma_framework/contracts/poc/fast_exits/QuasarPool.sol
@@ -2,64 +2,129 @@ pragma solidity 0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "../../src/utils/SafeEthTransfer.sol";
+import "./utils/Exponential.sol";
+import "./interfaces/IQToken.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 
-contract QuasarPool {
+contract QuasarPool is Exponential {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
+    struct Token {
+        address qTokenAddress;
+        uint256 exchangeRate;
+        uint256 owedAmount;
+        uint256 poolSupply;
+        uint256 quasarFee;
+    }
+
     address public quasarMaintainer;
     uint256 constant internal SAFE_GAS_STIPEND = 2300;
+    uint256 constant private INITIAL_EXCHANGE_RATE_SCALED = 2e15;
 
     modifier onlyQuasarMaintainer() {
         require(msg.sender == quasarMaintainer, "Only the Quasar Maintainer can invoke this method");
         _;
     }
     
+    mapping (address => Token) public tokenData;
     mapping (address => uint256) public tokenUsableCapacity;
     event QuasarTotalCapacityUpdated(address token, uint256 balance);
 
     /**
+     * Verify QToken contract before supplying
      * @dev Add Eth Liquid funds to the quasar
     */
     function addEthCapacity() public payable {
-        address token = address(0);
-        tokenUsableCapacity[token] = tokenUsableCapacity[token].add(msg.value);
-        emit QuasarTotalCapacityUpdated(token, tokenUsableCapacity[token]);
+        mintQTokens(address(0), msg.value);
     }
 
     /**
+     * Verify QToken contract before supplying
      * @dev Add ERC20 Liquid funds to the quasar
+     * @param token the token
+     * @param amount value to supply
     */
     function addTokenCapacity(address token, uint256 amount) public {
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+        mintQTokens(token, amount);
+    }
+
+    /**
+     * @dev Internal function, determine and mint tokens for supplier
+     * @param token the token
+     * @param amount value to supply
+    */
+    function mintQTokens(address token, uint256 amount) private {
+        require(tokenData[token].qTokenAddress != address(0), "QToken is not registered for the token");
+
         tokenUsableCapacity[token] = tokenUsableCapacity[token].add(amount);
+        tokenData[token].poolSupply = tokenData[token].poolSupply.add(amount);
+
+        // derive qTokens to mint
+        uint256 qTokenMintAmount = Exponential.divScalarByExpTruncate(amount, Exp({mantissa: tokenData[token].exchangeRate}));
+        IQToken(tokenData[token].qTokenAddress).mint(msg.sender, qTokenMintAmount);
+
         emit QuasarTotalCapacityUpdated(token, tokenUsableCapacity[token]);
     }
 
     /**
-     * @dev Withdraw Eth funds from the contract
-     * @param amount amount of Eth(in wei) to withdraw
+     * @dev Withdraw funds from the contract
+     * @param token the token
+     * @param amount amount (in number of qTokens) to withdraw
     */
-    function withdrawEth(uint256 amount) public onlyQuasarMaintainer() {
-        address token = address(0);
-        require(amount <= tokenUsableCapacity[token], "Amount should be lower than claimable funds");
-        tokenUsableCapacity[token] = tokenUsableCapacity[token].sub(amount);
-        SafeEthTransfer.transferRevertOnError(msg.sender, amount, SAFE_GAS_STIPEND);
+    function withdrawFunds(address token, uint256 amount) public {
+        address qToken = tokenData[token].qTokenAddress;
+        uint256 qTokenBalance = IERC20(qToken).balanceOf(msg.sender);
+        require(amount <= qTokenBalance, "Not enough qToken Balance");
+
+        // derive amount from number of qTokens
+        uint256 tokenWithdrawable = Exponential.mulScalarTruncate(Exp({mantissa: tokenData[token].exchangeRate}), amount);
+        require(tokenWithdrawable <= tokenUsableCapacity[token], "Amount should be lower than claimable funds");
+
+        tokenUsableCapacity[token] = tokenUsableCapacity[token].sub(tokenWithdrawable);
+        tokenData[token].poolSupply = tokenData[token].poolSupply.sub(tokenWithdrawable);
+
+        // burn qTokens from supply
+        IQToken(qToken).burn(msg.sender, amount);
+
+        if (token == address(0)) {
+            SafeEthTransfer.transferRevertOnError(msg.sender, tokenWithdrawable, SAFE_GAS_STIPEND);
+        } else {
+            IERC20(token).safeTransfer(msg.sender, tokenWithdrawable);
+        }
+
         emit QuasarTotalCapacityUpdated(token, tokenUsableCapacity[token]);
     }
 
     /**
-     * @dev Withdraw Erc20 funds from the contract
-     * @param token the erc20 token
-     * @param amount amount of the token to withdraw
+     * Higher decimal for erc20 preffered
+     * @dev Register a token to be allowed, deploy qToken first
+     * @param token the token
+     * @param qTokenContract the address of the qToken contract
+     * @param quasarFee amount (in token's denomination) to be used as a fee
     */
-    function withdrawErc20(address token, uint256 amount) public onlyQuasarMaintainer() {
-        require(amount <= tokenUsableCapacity[token], "Amount should be lower than claimable funds");
-        tokenUsableCapacity[token] = tokenUsableCapacity[token].sub(amount);
-        IERC20(token).safeTransfer(msg.sender, amount);
-        emit QuasarTotalCapacityUpdated(token, tokenUsableCapacity[token]);
+    function registerQToken(address token, address qTokenContract, uint256 quasarFee) public onlyQuasarMaintainer() {
+        require(tokenData[token].qTokenAddress == address(0), "QToken for the token already exists");
+        tokenData[token] = Token(qTokenContract, INITIAL_EXCHANGE_RATE_SCALED, 0, 0, quasarFee);
+    }
+
+    /**
+     * @dev Repay owed funds to the pool
+     * @param token the token
+     * @param amount amount to repay
+    */
+    function repayOwedToken(address token, uint256 amount) public payable {
+        if (token == address(0)) {
+            amount = msg.value;
+        } else {
+            IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        }
+
+        tokenUsableCapacity[token] = tokenUsableCapacity[token].add(amount);
+        tokenData[token].owedAmount = tokenData[token].owedAmount.sub(amount);   
     }
 }

--- a/plasma_framework/contracts/poc/fast_exits/interfaces/IQToken.sol
+++ b/plasma_framework/contracts/poc/fast_exits/interfaces/IQToken.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.5.11;
+
+interface IQToken {
+    function mint(address account, uint256 amount) external;
+
+    function burn(address account, uint256 value) external; 
+}

--- a/plasma_framework/contracts/poc/fast_exits/utils/Exponential.sol
+++ b/plasma_framework/contracts/poc/fast_exits/utils/Exponential.sol
@@ -1,0 +1,72 @@
+pragma solidity 0.5.11;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+/**
+ * Credit: Derived from Compound's Exponential contract
+ */
+contract Exponential {
+    using SafeMath for uint256;
+
+    uint256 constant private expScale = 1e18;
+
+    struct Exp {
+        uint256 mantissa;
+    }
+
+    /**
+     * @dev Creates an exponential from numerator and denominator values
+     */
+    function getExp(uint256 num, uint256 denom) pure internal returns (Exp memory) {
+        uint256 scaledNumerator = num.mul(expScale);
+
+        uint256 rational = scaledNumerator.div(denom);
+
+        return (Exp({mantissa: rational}));
+    }
+
+    /**
+     * @dev Multiply an Exp by a scalar, returning a new Exp.
+     */
+    function mulScalar(Exp memory a, uint256 scalar) pure internal returns (Exp memory) {
+        uint256 scaledMantissa = a.mantissa.mul(scalar);
+
+        return (Exp({mantissa: scaledMantissa}));
+    }
+
+    /**
+     * @dev Multiply an Exp by a scalar, then truncate to return an unsigned integer.
+     */
+    function mulScalarTruncate(Exp memory a, uint256 scalar) pure internal returns (uint) {
+        Exp memory product = mulScalar(a, scalar);
+
+        return (truncate(product));
+    }
+
+    /**
+     * @dev Divide a scalar by an Exp, returning a new Exp.
+     */
+    function divScalarByExp(uint256 scalar, Exp memory divisor) pure internal returns (Exp memory) {
+        uint numerator = expScale.mul(scalar);
+
+        return getExp(numerator, divisor.mantissa);
+    }
+
+    /**
+     * @dev Divide a scalar by an Exp, then truncate to return an unsigned integer.
+     */
+    function divScalarByExpTruncate(uint scalar, Exp memory divisor) pure internal returns (uint) {
+        Exp memory fraction = divScalarByExp(scalar, divisor);
+
+        return (truncate(fraction));
+    }
+
+    /**
+     * @dev Truncates the given exp to a whole number value.
+     *      For example, truncate(Exp{mantissa: 15 * expScale}) = 15
+     */
+    function truncate(Exp memory exp) pure internal returns (uint) {
+        return exp.mantissa / expScale;
+    }
+
+}

--- a/plasma_framework/contracts/poc/fast_exits/utils/Exponential.sol
+++ b/plasma_framework/contracts/poc/fast_exits/utils/Exponential.sol
@@ -8,7 +8,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 contract Exponential {
     using SafeMath for uint256;
 
-    uint256 constant private expScale = 1e18;
+    uint256 constant private EXP_SCALE = 1e18;
 
     struct Exp {
         uint256 mantissa;
@@ -17,8 +17,8 @@ contract Exponential {
     /**
      * @dev Creates an exponential from numerator and denominator values
      */
-    function getExp(uint256 num, uint256 denom) pure internal returns (Exp memory) {
-        uint256 scaledNumerator = num.mul(expScale);
+    function getExp(uint256 num, uint256 denom) internal pure returns (Exp memory) {
+        uint256 scaledNumerator = num.mul(EXP_SCALE);
 
         uint256 rational = scaledNumerator.div(denom);
 
@@ -28,7 +28,7 @@ contract Exponential {
     /**
      * @dev Multiply an Exp by a scalar, returning a new Exp.
      */
-    function mulScalar(Exp memory a, uint256 scalar) pure internal returns (Exp memory) {
+    function mulScalar(Exp memory a, uint256 scalar) internal pure returns (Exp memory) {
         uint256 scaledMantissa = a.mantissa.mul(scalar);
 
         return (Exp({mantissa: scaledMantissa}));
@@ -37,7 +37,7 @@ contract Exponential {
     /**
      * @dev Multiply an Exp by a scalar, then truncate to return an unsigned integer.
      */
-    function mulScalarTruncate(Exp memory a, uint256 scalar) pure internal returns (uint) {
+    function mulScalarTruncate(Exp memory a, uint256 scalar) internal pure returns (uint) {
         Exp memory product = mulScalar(a, scalar);
 
         return (truncate(product));
@@ -46,8 +46,8 @@ contract Exponential {
     /**
      * @dev Divide a scalar by an Exp, returning a new Exp.
      */
-    function divScalarByExp(uint256 scalar, Exp memory divisor) pure internal returns (Exp memory) {
-        uint numerator = expScale.mul(scalar);
+    function divScalarByExp(uint256 scalar, Exp memory divisor) internal pure returns (Exp memory) {
+        uint numerator = EXP_SCALE.mul(scalar);
 
         return getExp(numerator, divisor.mantissa);
     }
@@ -55,7 +55,7 @@ contract Exponential {
     /**
      * @dev Divide a scalar by an Exp, then truncate to return an unsigned integer.
      */
-    function divScalarByExpTruncate(uint scalar, Exp memory divisor) pure internal returns (uint) {
+    function divScalarByExpTruncate(uint scalar, Exp memory divisor) internal pure returns (uint) {
         Exp memory fraction = divScalarByExp(scalar, divisor);
 
         return (truncate(fraction));
@@ -63,10 +63,10 @@ contract Exponential {
 
     /**
      * @dev Truncates the given exp to a whole number value.
-     *      For example, truncate(Exp{mantissa: 15 * expScale}) = 15
+     *      For example, truncate(Exp{mantissa: 15 * EXP_SCALE}) = 15
      */
-    function truncate(Exp memory exp) pure internal returns (uint) {
-        return exp.mantissa / expScale;
+    function truncate(Exp memory exp) internal pure returns (uint) {
+        return exp.mantissa / EXP_SCALE;
     }
 
 }

--- a/plasma_framework/test/endToEndTests/QuasarExit.e2e.test.js
+++ b/plasma_framework/test/endToEndTests/QuasarExit.e2e.test.js
@@ -822,14 +822,14 @@ contract(
                                         );
 
                                         const expectedQuasarMaintainerBalance = quasarMaintainerBalanceBeforeWithdraw
-                                        .add(this.qMaintainerWithdrawAmount)
-                                        .addn(this.dummyQuasarBondValue)
-                                        .sub(await spentOnGas(txUnclaimedBonds.receipt))
-                                        .sub(await spentOnGas(txEthWithdrawal.receipt));
+                                            .add(this.qMaintainerWithdrawAmount)
+                                            .addn(this.dummyQuasarBondValue)
+                                            .sub(await spentOnGas(txUnclaimedBonds.receipt))
+                                            .sub(await spentOnGas(txEthWithdrawal.receipt));
 
                                         expect(quasarMaintainerBalanceAfterWithdraw).to.be.bignumber.equal(
                                             expectedQuasarMaintainerBalance,
-                                        )
+                                        );
                                     });
                                 });
                             });
@@ -1691,8 +1691,15 @@ contract(
                                             this.carolQTokenBalance = await this.qEth.balanceOf(carol);
 
                                             const { exchangeRate } = await this.quasar.tokenData(ETH);
-                                            this.bobWithdrawAmount = await calculateWithdrawAmount(this.bobQTokenBalance, exchangeRate);
-                                            this.carolWithdrawAmount = await calculateWithdrawAmount(this.carolQTokenBalance, exchangeRate);
+                                            this.bobWithdrawAmount = await calculateWithdrawAmount(
+                                                this.bobQTokenBalance,
+                                                exchangeRate,
+                                            );
+
+                                            this.carolWithdrawAmount = await calculateWithdrawAmount(
+                                                this.carolQTokenBalance,
+                                                exchangeRate,
+                                            );
 
                                             this.bobWithdrawTx = await this.quasar.withdrawFunds(
                                                 ETH,
@@ -1728,7 +1735,8 @@ contract(
                                                 quasarBalance,
                                             ).equal(poolSupply);
 
-                                            // some residue might remain in the pool due to rounding down while withdrawing
+                                            // some residue might remain in the pool
+                                            // due to rounding down while withdrawing
                                             // expect the residue to be very small
                                             expect(quasarBalance).to.be.bignumber.at.most(
                                                 new BN(10),
@@ -1743,14 +1751,18 @@ contract(
                                                 await spentOnGas(this.bobWithdrawTx.receipt),
                                             ).sub(this.bobBalanceBeforeWithdraw).subn(this.bobSuppliedFunds);
 
-                                            const expectedBobReturnProfit = this.bobWithdrawAmount.subn(this.bobSuppliedFunds);
+                                            const expectedBobReturnProfit = this.bobWithdrawAmount.subn(
+                                                this.bobSuppliedFunds,
+                                            );
                                             expect(bobReturnProfit).to.be.bignumber.equal(expectedBobReturnProfit);
 
                                             const carolReturnProfit = carolBalanceAfterWithdraw.add(
                                                 await spentOnGas(this.carolWithdrawTx.receipt),
                                             ).sub(this.carolBalanceBeforeWithdraw).subn(this.carolSuppliedFunds);
 
-                                            const expectedCarolReturnProfit = this.carolWithdrawAmount.subn(this.carolSuppliedFunds);
+                                            const expectedCarolReturnProfit = this.carolWithdrawAmount.subn(
+                                                this.carolSuppliedFunds,
+                                            );
                                             expect(carolReturnProfit).to.be.bignumber.equal(expectedCarolReturnProfit);
 
                                             expect(carolReturnProfit).be.bignumber.above(bobReturnProfit);
@@ -1841,7 +1853,10 @@ contract(
                                     this.bobBalanceBeforeWithdraw = new BN(await web3.eth.getBalance(bob));
 
                                     const { exchangeRate } = await this.quasar.tokenData(ETH);
-                                    this.bobWithdrawAmount = await calculateWithdrawAmount(this.bobQTokenBalance, exchangeRate);
+                                    this.bobWithdrawAmount = await calculateWithdrawAmount(
+                                        this.bobQTokenBalance,
+                                        exchangeRate,
+                                    );
 
                                     this.bobWithdrawTx = await this.quasar.withdrawFunds(
                                         ETH,
@@ -1940,8 +1955,15 @@ contract(
                                                 const daveQTokenBalance = new BN(await this.qEth.balanceOf(dave));
 
                                                 const { exchangeRate } = await this.quasar.tokenData(ETH);
-                                                this.carolWithdrawAmount = await calculateWithdrawAmount(carolQTokenBalance, exchangeRate);
-                                                this.daveWithdrawAmount = await calculateWithdrawAmount(daveQTokenBalance, exchangeRate);
+                                                this.carolWithdrawAmount = await calculateWithdrawAmount(
+                                                    carolQTokenBalance,
+                                                    exchangeRate,
+                                                );
+
+                                                this.daveWithdrawAmount = await calculateWithdrawAmount(
+                                                    daveQTokenBalance,
+                                                    exchangeRate,
+                                                );
 
 
                                                 this.carolWithdrawTx = await this.quasar.withdrawFunds(
@@ -1986,7 +2008,8 @@ contract(
                                                     quasarBalance,
                                                 ).equal(poolSupply);
 
-                                                // some residue might remain in the pool due to rounding down while withdrawing
+                                                // some residue might remain in the pool
+                                                // due to rounding down while withdrawing
                                                 // expect the residue to be very small
                                                 expect(quasarBalance).to.be.bignumber.at.most(
                                                     new BN(10),
@@ -2008,22 +2031,32 @@ contract(
                                                     await spentOnGas(this.bobWithdrawTx.receipt),
                                                 ).sub(this.bobBalanceBeforeWithdraw).subn(this.bobSuppliedFunds);
 
-                                                const expectedBobReturnProfit = this.bobWithdrawAmount.subn(this.bobSuppliedFunds);
+                                                const expectedBobReturnProfit = this.bobWithdrawAmount.subn(
+                                                    this.bobSuppliedFunds,
+                                                );
                                                 expect(bobReturnProfit).to.be.bignumber.equal(expectedBobReturnProfit);
 
                                                 const carolReturnProfit = carolBalanceAfterWithdraw.add(
                                                     await spentOnGas(this.carolWithdrawTx.receipt),
                                                 ).sub(this.carolBalanceBeforeWithdraw).subn(this.carolSuppliedFunds);
 
-                                                const expectedCarolReturnProfit = this.carolWithdrawAmount.subn(this.carolSuppliedFunds);
-                                                expect(carolReturnProfit).to.be.bignumber.equal(expectedCarolReturnProfit);
+                                                const expectedCarolReturnProfit = this.carolWithdrawAmount.subn(
+                                                    this.carolSuppliedFunds,
+                                                );
+                                                expect(carolReturnProfit).to.be.bignumber.equal(
+                                                    expectedCarolReturnProfit,
+                                                );
 
                                                 const daveReturnProfit = daveBalanceAfterWithdraw.add(
                                                     await spentOnGas(this.daveWithdrawTx.receipt),
                                                 ).sub(this.daveBalanceBeforeWithdraw).subn(this.daveSuppliedFunds);
 
-                                                const expectedDaveReturnProfit = this.daveWithdrawAmount.subn(this.daveSuppliedFunds);
-                                                expect(daveReturnProfit).to.be.bignumber.equal(expectedDaveReturnProfit);
+                                                const expectedDaveReturnProfit = this.daveWithdrawAmount.subn(
+                                                    this.daveSuppliedFunds,
+                                                );
+                                                expect(daveReturnProfit).to.be.bignumber.equal(
+                                                    expectedDaveReturnProfit,
+                                                );
 
                                                 expect(carolReturnProfit).be.bignumber.above(bobReturnProfit);
                                                 expect(carolReturnProfit).be.bignumber.above(daveReturnProfit);
@@ -2179,7 +2212,10 @@ contract(
                                     this.withdrawTokens = new BN((this.bobQTokenBalance / 2).toFixed());
 
                                     const { exchangeRate } = await this.quasar.tokenData(this.erc20.address);
-                                    this.bobWithdrawAmountFirstRound = await calculateWithdrawAmount(this.withdrawTokens, exchangeRate);
+                                    this.bobWithdrawAmountFirstRound = await calculateWithdrawAmount(
+                                        this.withdrawTokens,
+                                        exchangeRate,
+                                    );
 
                                     this.bobWithdrawTx = await this.quasar.withdrawFunds(
                                         this.erc20.address,
@@ -2275,8 +2311,13 @@ contract(
 
                                                 const bobQTokenBalance = await this.qErc20.balanceOf(bob);
 
-                                                const { exchangeRate } = await this.quasar.tokenData(this.erc20.address);
-                                                this.bobWithdrawAmountSecondRound = await calculateWithdrawAmount(bobQTokenBalance, exchangeRate);
+                                                const { exchangeRate } = await this.quasar.tokenData(
+                                                    this.erc20.address,
+                                                );
+                                                this.bobWithdrawAmountSecondRound = await calculateWithdrawAmount(
+                                                    bobQTokenBalance,
+                                                    exchangeRate,
+                                                );
 
                                                 this.bobWithdrawTx = await this.quasar.withdrawFunds(
                                                     this.erc20.address,
@@ -2285,7 +2326,10 @@ contract(
                                                 );
                                                 const carolQTokenBalance = await this.qErc20.balanceOf(carol);
 
-                                                this.carolWithdrawAmount = await calculateWithdrawAmount(carolQTokenBalance, exchangeRate);
+                                                this.carolWithdrawAmount = await calculateWithdrawAmount(
+                                                    carolQTokenBalance,
+                                                    exchangeRate,
+                                                );
 
                                                 this.carolWithdrawTx = await this.quasar.withdrawFunds(
                                                     this.erc20.address,
@@ -2297,7 +2341,7 @@ contract(
                                                     quasarMaintainer,
                                                 );
 
-                                                this.quasarMaintainerWithdrawAmount = await calculateWithdrawAmount(
+                                                this.qMaintainerWithdrawAmount = await calculateWithdrawAmount(
                                                     quasarMaintainerQTokenBalance,
                                                     exchangeRate,
                                                 );
@@ -2334,7 +2378,8 @@ contract(
                                                 const { poolSupply } = await this.quasar.tokenData(this.erc20.address);
 
                                                 expect(quasarCapacityAfterWithdraw).to.be.bignumber.equal(poolSupply);
-                                                // some residue might remain in the pool due to rounding down while withdrawing
+                                                // some residue might remain in the pool
+                                                // due to rounding down while withdrawing
                                                 // expect the residue to be very small
                                                 expect(quasarCapacityAfterWithdraw).to.be.bignumber.at.most(
                                                     new BN(10),
@@ -2361,17 +2406,23 @@ contract(
                                                     this.carolBalanceBeforeWithdraw,
                                                 ).subn(this.carolSuppliedERC20Funds);
 
-                                                const expectedCarolReturnProfit = this.carolWithdrawAmount.subn(this.carolSuppliedERC20Funds);
-                                                expect(carolReturnProfit).to.be.bignumber.equal(expectedCarolReturnProfit);
+                                                const expectedCarolReturnProfit = this.carolWithdrawAmount.subn(
+                                                    this.carolSuppliedERC20Funds,
+                                                );
+                                                expect(carolReturnProfit).to.be.bignumber.equal(
+                                                    expectedCarolReturnProfit,
+                                                );
 
                                                 const qMaintainerReturnProfit = qMaintainerBalanceAfterWithdraw.sub(
                                                     this.qMaintainerBalanceBeforeWithdraw,
                                                 ).subn(QUASAR_LIQUID_FUNDS);
 
-                                                const expectedQMaintainerReturnProfit = this.quasarMaintainerWithdrawAmount.subn(
+                                                const expectedQMaintainerReturn = this.qMaintainerWithdrawAmount.subn(
                                                     QUASAR_LIQUID_FUNDS,
                                                 );
-                                                expect(qMaintainerReturnProfit).to.be.bignumber.equal(expectedQMaintainerReturnProfit);
+                                                expect(qMaintainerReturnProfit).to.be.bignumber.equal(
+                                                    expectedQMaintainerReturn,
+                                                );
 
                                                 expect(qMaintainerReturnProfit).to.be.bignumber.above(
                                                     carolReturnProfit,

--- a/plasma_framework/test/endToEndTests/QuasarExit.e2e.test.js
+++ b/plasma_framework/test/endToEndTests/QuasarExit.e2e.test.js
@@ -2,6 +2,7 @@ const PaymentExitGame = artifacts.require('PaymentExitGame');
 const PlasmaFramework = artifacts.require('PlasmaFramework');
 const SpendingConditionRegistry = artifacts.require('SpendingConditionRegistry');
 const Quasar = artifacts.require('../Quasar');
+const QToken = artifacts.require('QToken');
 const EthVault = artifacts.require('EthVault');
 const Erc20Vault = artifacts.require('Erc20Vault');
 const ERC20Mintable = artifacts.require('ERC20Mintable');
@@ -22,7 +23,7 @@ const config = require('../../config.js');
 
 contract(
     'QuasarContract - Fast Exits - End to End Tests',
-    ([_deployer, _maintainer, authority, bob, richDad, quasarMaintainer, quasarOwner]) => {
+    ([_deployer, _maintainer, authority, bob, richDad, quasarMaintainer, quasarOwner, carol, dave]) => {
         const ETH = constants.ZERO_ADDRESS;
         const OUTPUT_TYPE_PAYMENT = config.registerKeys.outputTypes.payment;
         const INITIAL_ERC20_SUPPLY = 10000000000;
@@ -90,6 +91,14 @@ contract(
                 { from: quasarMaintainer },
             );
             this.ifeWaitingPeriod = await this.quasar.IFE_CLAIM_WAITING_PERIOD();
+            this.qEth = await QToken.new('Quasar Ether', 'qETH', 18, this.quasar.address);
+            await this.quasar.registerQToken(
+                ETH,
+                this.qEth.address,
+                5000,
+                { from: quasarMaintainer },
+            );
+            this.quasarFeeEth = (await this.quasar.tokenData(ETH)).quasarFee;
         };
 
         const aliceDepositsETH = async () => {
@@ -162,6 +171,8 @@ contract(
             await this.framework.submitBlock(this.merkleTreeForTransferTx.root, { from: authority });
         };
 
+        // Single Supplier
+        // ---------------->
         describe('Given contracts deployed, exit game and ETH vault registered', () => {
             before(setupContracts);
 
@@ -301,7 +312,9 @@ contract(
                                         expectedValidityTimestamp,
                                     );
                                     expect(ticketData.outputOwner).to.be.equal(alice);
-                                    expect(ticketData.reservedAmount).to.be.bignumber.equal(new BN(DEPOSIT_VALUE));
+                                    expect(ticketData.outputValue).to.be.bignumber.equal(new BN(DEPOSIT_VALUE));
+                                    const expectedReservedAmount = new BN(DEPOSIT_VALUE - this.quasarFeeEth);
+                                    expect(ticketData.reservedAmount).to.be.bignumber.equal(expectedReservedAmount);
                                     expect(ticketData.token).to.be.equal(ETH);
                                     expect(ticketData.bondValue).to.be.bignumber.equal(
                                         new BN(this.dummyQuasarBondValue),
@@ -312,7 +325,7 @@ contract(
                                 it('should reduce the Quasar capacity for ETH', async () => {
                                     const updatedQuasarCapacity = new BN(await this.quasar.tokenUsableCapacity(ETH));
                                     const expectedQuasarCapacity = this.quasarCapacityBeforeObtainingTicket.subn(
-                                        DEPOSIT_VALUE,
+                                        DEPOSIT_VALUE - this.quasarFeeEth,
                                     );
 
                                     expect(updatedQuasarCapacity).to.be.bignumber.equal(expectedQuasarCapacity);
@@ -421,7 +434,7 @@ contract(
                                             const rlpTxToQuasarOwner = this.transferTx;
                                             const txToQuasarOwnerInclusionProof = this.merkleProofForTransferTx;
 
-                                            this.aliceBalanceBeforeprocessIfeClaim = new BN(
+                                            this.aliceBalanceBeforeClaim = new BN(
                                                 await web3.eth.getBalance(alice),
                                             );
 
@@ -443,18 +456,31 @@ contract(
                                         });
 
                                         it('should return the amount plus bond to Alice', async () => {
-                                            const aliceBalanceAfterprocessIfeClaim = new BN(
+                                            const aliceBalanceAfterClaim = new BN(
                                                 await web3.eth.getBalance(alice),
                                             );
-                                            const expectedAliceBalance = this.aliceBalanceBeforeprocessIfeClaim
-                                                .addn(DEPOSIT_VALUE)
+                                            const ticketData = await this.quasar.ticketData(this.depositUtxoPos);
+                                            const expectedAliceBalance = this.aliceBalanceBeforeClaim
+                                                .add(ticketData.reservedAmount)
                                                 .addn(this.dummyQuasarBondValue)
                                                 .sub(await spentOnGas(this.claimReceipt));
 
-                                            expect(aliceBalanceAfterprocessIfeClaim).to.be.bignumber.equal(
+                                            expect(aliceBalanceAfterClaim).to.be.bignumber.equal(
                                                 expectedAliceBalance,
                                             );
                                         });
+
+                                        it('should correctly set the owed Amount for ETH', async () => {
+                                            const updatedQuasarCapacity = new BN(
+                                                await this.quasar.tokenUsableCapacity(ETH),
+                                            );
+                                            const { owedAmount } = await this.quasar.tokenData(ETH);
+                                            const { poolSupply } = await this.quasar.tokenData(ETH);
+                                            const expectedPoolSupply = updatedQuasarCapacity.add(owedAmount);
+
+                                            expect(poolSupply).to.be.bignumber.equal(expectedPoolSupply);
+                                        });
+
 
                                         it('should not allow to claim same ticket again', async () => {
                                             const utxoPos = this.depositUtxoPos;
@@ -615,7 +641,7 @@ contract(
                                         await this.quasar.tokenUsableCapacity(ETH),
                                     );
                                     const quasarExpectedCapacity = this.quasarCapacityBeforeChallenge.addn(
-                                        DEPOSIT_VALUE,
+                                        DEPOSIT_VALUE - this.quasarFeeEth,
                                     );
 
                                     expect(quasarExpectedCapacity).to.be.bignumber.equal(quasarCapacityAfterChallenge);
@@ -635,7 +661,7 @@ contract(
                     });
                 });
 
-                describe('Given Alice deposited ETH and transferred somee to Bob', () => {
+                describe('Given Alice deposited ETH and transferred some to Bob', () => {
                     before(async () => {
                         await aliceDepositsETH();
                         await aliceTransferEth(bob, DEPOSIT_VALUE / 2);
@@ -712,7 +738,7 @@ contract(
                                 it('should free the quasar capacity and add bond value to reserve', async () => {
                                     const quasarCapacityAfterFlush = new BN(await this.quasar.tokenUsableCapacity(ETH));
                                     const quasarExpectedCapacity = this.quasarCapacityBeforeFlush.addn(
-                                        DEPOSIT_VALUE / 2,
+                                        (DEPOSIT_VALUE / 2) - this.quasarFeeEth,
                                     );
 
                                     expect(quasarCapacityAfterFlush).to.be.bignumber.equal(quasarExpectedCapacity);
@@ -726,19 +752,30 @@ contract(
                                 });
 
                                 describe('When the Quasar Maintainer tries to withdraw unreserved funds plus the unclaimed bonds ', () => {
+                                    // add before repay here
+                                    before(async () => {
+                                        const { owedAmount } = await this.quasar.tokenData(ETH);
+                                        await this.quasar.repayOwedToken(ETH, 0, { value: owedAmount });
+                                    });
+
                                     it('should not allow to withdraw if withdrawal amount is more than claimable funds', async () => {
-                                        const quasarCapacity = new BN(await this.quasar.tokenUsableCapacity(ETH));
-                                        const withdrawableFunds = quasarCapacity.addn(1);
+                                        const qToken = await this.quasar.tokenData(ETH);
+                                        const qETHContract = await QToken.at(qToken.qTokenAddress);
+                                        this.quasarMaintainerQTokenBalance = await qETHContract.balanceOf(
+                                            quasarMaintainer,
+                                        );
+                                        const withdrawableFunds = this.quasarMaintainerQTokenBalance.addn(1);
                                         await expectRevert(
-                                            this.quasar.withdrawEth(
+                                            this.quasar.withdrawFunds(
+                                                ETH,
                                                 withdrawableFunds,
                                                 { from: quasarMaintainer },
                                             ),
-                                            'Amount should be lower than claimable funds',
+                                            'Not enough qToken Balance',
                                         );
                                     });
 
-                                    it('should allow to withdraw all claimable funds', async () => {
+                                    it('should allow to withdraw all claimable funds(qTokens)', async () => {
                                         const quasarCapacity = new BN(await this.quasar.tokenUsableCapacity(ETH));
                                         const quasarContractBalance = new BN(
                                             await web3.eth.getBalance(this.quasar.address),
@@ -755,10 +792,19 @@ contract(
                                             { from: quasarMaintainer },
                                         );
 
-                                        const txEthWithdrawal = await this.quasar.withdrawEth(
-                                            quasarCapacity,
+                                        const txEthWithdrawal = await this.quasar.withdrawFunds(
+                                            ETH,
+                                            this.quasarMaintainerQTokenBalance,
                                             { from: quasarMaintainer },
                                         );
+
+                                        const qToken = await this.quasar.tokenData(ETH);
+                                        const qETHContract = await QToken.at(qToken.qTokenAddress);
+                                        const quasarMaintainerQTokenBalance = await qETHContract.balanceOf(
+                                            quasarMaintainer,
+                                        );
+
+                                        expect(quasarMaintainerQTokenBalance).to.be.bignumber.equal(new BN(0));
 
                                         const quasarMaintainerBalanceAfterWithdraw = new BN(
                                             await web3.eth.getBalance(quasarMaintainer),
@@ -770,9 +816,9 @@ contract(
                                             .sub(await spentOnGas(txUnclaimedBonds.receipt))
                                             .sub(await spentOnGas(txEthWithdrawal.receipt));
 
-                                        expect(quasarMaintainerBalanceAfterWithdraw).to.be.bignumber.equal(
+                                        expect(quasarMaintainerBalanceAfterWithdraw).to.be.bignumber.at.most(
                                             expectedQuasarMaintainerBalance,
-                                        );
+                                        ).at.least(expectedQuasarMaintainerBalance.subn(10));
                                     });
                                 });
                             });
@@ -950,6 +996,7 @@ contract(
                                             });
                                             it('should allow to process claim and return the amount plus bond to Alice', async () => {
                                                 const utxoPos = this.depositUtxoPos;
+                                                const ticketData = await this.quasar.ticketData(utxoPos);
                                                 const aliceBalanceBeforeprocessIfeClaim = new BN(
                                                     await web3.eth.getBalance(alice),
                                                 );
@@ -957,8 +1004,8 @@ contract(
                                                 const aliceBalanceAfterprocessIfeClaim = new BN(
                                                     await web3.eth.getBalance(alice),
                                                 );
-                                                const expectedAliceBalance = aliceBalanceBeforeprocessIfeClaim.addn(
-                                                    DEPOSIT_VALUE,
+                                                const expectedAliceBalance = aliceBalanceBeforeprocessIfeClaim.add(
+                                                    ticketData.reservedAmount,
                                                 ).addn(this.dummyQuasarBondValue);
 
                                                 expect(aliceBalanceAfterprocessIfeClaim).to.be.bignumber.equal(
@@ -1099,7 +1146,7 @@ contract(
                                         await this.quasar.tokenUsableCapacity(ETH),
                                     );
                                     const quasarExpectedCapacity = this.quasarCapacityBeforeChallenge.addn(
-                                        DEPOSIT_VALUE,
+                                        DEPOSIT_VALUE - this.quasarFeeEth,
                                     );
 
                                     expect(quasarExpectedCapacity).to.be.bignumber.equal(quasarCapacityAfterChallenge);
@@ -1276,7 +1323,7 @@ contract(
                                             await this.quasar.tokenUsableCapacity(ETH),
                                         );
                                         const quasarExpectedCapacity = this.quasarCapacityBeforeChallenge.addn(
-                                            DEPOSIT_VALUE,
+                                            DEPOSIT_VALUE - this.quasarFeeEth,
                                         );
 
                                         expect(quasarExpectedCapacity).to.be.bignumber.equal(
@@ -1302,6 +1349,16 @@ contract(
                 describe('When Quasar maintainer adds liquid erc20 funds to the Quasar', () => {
                     before(async () => {
                         await setupQuasar();
+                        // deploy and register qErc20
+                        this.qErc20 = await QToken.new('Quasar Token', 'qERC', 18, this.quasar.address);
+                        await this.quasar.registerQToken(
+                            this.erc20.address,
+                            this.qErc20.address,
+                            5000,
+                            { from: quasarMaintainer },
+                        );
+                        this.quasarFeeErc = (await this.quasar.tokenData(this.erc20.address)).quasarFee;
+
                         this.quasarCapacityBeforeAddingFunds = new BN(
                             await this.quasar.tokenUsableCapacity(this.erc20.address),
                         );
@@ -1372,7 +1429,9 @@ contract(
                                             expectedValidityTimestamp,
                                         );
                                         expect(ticketData.outputOwner).to.be.equal(alice);
-                                        expect(ticketData.reservedAmount).to.be.bignumber.equal(new BN(DEPOSIT_VALUE));
+                                        expect(ticketData.outputValue).to.be.bignumber.equal(new BN(DEPOSIT_VALUE));
+                                        const expectedReservedAmount = new BN(DEPOSIT_VALUE - this.quasarFeeErc);
+                                        expect(ticketData.reservedAmount).to.be.bignumber.equal(expectedReservedAmount);
                                         expect(ticketData.token).to.be.equal(this.erc20.address);
                                         expect(ticketData.bondValue).to.be.bignumber.equal(
                                             new BN(this.dummyQuasarBondValue),
@@ -1385,7 +1444,7 @@ contract(
                                             await this.quasar.tokenUsableCapacity(this.erc20.address),
                                         );
                                         const expectedQuasarCapacity = this.quasarCapacityBeforeObtainingTicket.subn(
-                                            DEPOSIT_VALUE,
+                                            DEPOSIT_VALUE - this.quasarFeeErc,
                                         );
 
                                         expect(updatedQuasarCapacity).to.be.bignumber.equal(expectedQuasarCapacity);
@@ -1429,10 +1488,10 @@ contract(
                                                 const rlpTxToQuasarOwner = this.transferTx;
                                                 const txToQuasarOwnerInclusionProof = this.merkleProofForTransferTx;
 
-                                                this.ethBalanceBeforeprocessIfeClaim = new BN(
+                                                this.ethBalanceBeforeClaim = new BN(
                                                     await web3.eth.getBalance(alice),
                                                 );
-                                                this.erc20BalanceBeforeprocessIfeClaim = new BN(
+                                                this.erc20BalanceBeforeClaim = new BN(
                                                     await this.erc20.balanceOf(alice),
                                                 );
 
@@ -1452,22 +1511,22 @@ contract(
                                                 const ticketData = await this.quasar.ticketData(this.depositUtxoPos);
                                                 expect(ticketData.isClaimed).to.be.true;
 
-                                                const ethBalanceAfterprocessIfeClaim = new BN(
+                                                const ethBalanceAfterClaim = new BN(
                                                     await web3.eth.getBalance(alice),
                                                 );
-                                                const erc20BalanceAfterprocessIfeClaim = new BN(
+                                                const erc20BalanceAfterClaim = new BN(
                                                     await this.erc20.balanceOf(alice),
                                                 );
-                                                const expectedEthBalance = this.ethBalanceBeforeprocessIfeClaim
+                                                const expectedEthBalance = this.ethBalanceBeforeClaim
                                                     .addn(this.dummyQuasarBondValue)
                                                     .sub(await spentOnGas(this.claimReceipt));
-                                                const expectedErc20Balance = this.erc20BalanceBeforeprocessIfeClaim
-                                                    .addn(DEPOSIT_VALUE);
+                                                const expectedErc20Balance = this.erc20BalanceBeforeClaim
+                                                    .add(ticketData.reservedAmount);
 
-                                                expect(ethBalanceAfterprocessIfeClaim).to.be.bignumber.equal(
+                                                expect(ethBalanceAfterClaim).to.be.bignumber.equal(
                                                     expectedEthBalance,
                                                 );
-                                                expect(erc20BalanceAfterprocessIfeClaim).to.be.bignumber.equal(
+                                                expect(erc20BalanceAfterClaim).to.be.bignumber.equal(
                                                     expectedErc20Balance,
                                                 );
                                             });
@@ -1476,6 +1535,776 @@ contract(
                                                 await expectRevert(
                                                     this.quasar.processIfeClaim(utxoPos),
                                                     'The claim has already been claimed or challenged',
+                                                );
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+
+                // Multiple Suppliers
+                // ------------------->
+                /**
+                 * Scenario -
+                 * Bob and Carol supply ETH to the pool
+                 * After one round of claim, withdraw at the same time
+                */
+                describe('Scenario: Two suppliers, different supply amount', () => {
+                    describe('When Bob and Carol supply ETH to the pool', () => {
+                        before(async () => {
+                            this.quasarCapacityBeforeAddingFunds = new BN(await this.quasar.tokenUsableCapacity(ETH));
+                            this.bobSuppliedFunds = 1000000;
+                            this.carolSuppliedFunds = 2000000;
+                            await this.quasar.addEthCapacity({ from: bob, value: this.bobSuppliedFunds });
+                            await this.quasar.addEthCapacity({ from: carol, value: this.carolSuppliedFunds });
+                        });
+
+                        it('should increase the capacity of the Quasar', async () => {
+                            const quasarCapacityAfterAddingFunds = new BN(await this.quasar.tokenUsableCapacity(ETH));
+                            const quasarExpectedCapacity = this.quasarCapacityBeforeAddingFunds.addn(
+                                this.bobSuppliedFunds,
+                            ).addn(this.carolSuppliedFunds);
+
+                            expect(quasarCapacityAfterAddingFunds).to.be.bignumber.equal(
+                                quasarExpectedCapacity,
+                            );
+
+                            const quasarBalance = new BN(await web3.eth.getBalance(this.quasar.address));
+                            expect(quasarBalance).to.be.bignumber.equal(quasarCapacityAfterAddingFunds);
+                        });
+
+                        describe('Given Alice deposited ETH to Vault and obtains a ticket for the output', () => {
+                            before(async () => {
+                                await aliceDepositsETH();
+                                await submitPlasmaBlock();
+                                await submitPlasmaBlock();
+
+                                // Submit abother block for the safe margin
+                                const utxoPos = this.depositUtxoPos;
+                                const rlpOutputCreationTx = this.depositTx;
+                                const outputCreationTxInclusionProof = this.merkleProofForDepositTx;
+                                this.quasarCapacityBeforeTicket = new BN(await this.quasar.tokenUsableCapacity(ETH));
+                                await this.quasar.obtainTicket(
+                                    utxoPos,
+                                    rlpOutputCreationTx,
+                                    outputCreationTxInclusionProof,
+                                    {
+                                        from: alice,
+                                        value: this.dummyQuasarBondValue,
+                                    },
+                                );
+                            });
+
+                            describe('When Alice claims the ticket with the Tx to quasar owner', () => {
+                                before(async () => {
+                                    await aliceTransferEth(quasarOwner, DEPOSIT_VALUE);
+                                    const utxoPos = this.depositUtxoPos;
+                                    const utxoPosQuasarOwner = this.transferUtxoPos;
+                                    const rlpTxToQuasarOwner = this.transferTx;
+                                    const txToQuasarOwnerInclusionProof = this.merkleProofForTransferTx;
+
+                                    this.aliceBalanceBeforeClaim = new BN(
+                                        await web3.eth.getBalance(alice),
+                                    );
+                                    this.reservedAmount = (await this.quasar.ticketData(utxoPos)).reservedAmount;
+                                    this.poolSupplyBeforeClaim = (await this.quasar.tokenData(ETH)).poolSupply;
+                                    this.exchangeRateBeforeClaim = (await this.quasar.tokenData(ETH)).exchangeRate;
+
+                                    const { receipt } = await this.quasar.claim(
+                                        utxoPos,
+                                        utxoPosQuasarOwner,
+                                        rlpTxToQuasarOwner,
+                                        txToQuasarOwnerInclusionProof,
+                                        {
+                                            from: alice,
+                                        },
+                                    );
+                                    this.claimReceipt = receipt;
+                                });
+
+                                it('should update the owed capacity and usable capacity', async () => {
+                                    const quasarCapacityAfterClaim = new BN(await this.quasar.tokenUsableCapacity(ETH));
+                                    const expectedQuasarCapacity = this.quasarCapacityBeforeObtainingTicket.sub(
+                                        this.reservedAmount,
+                                    );
+
+                                    expect(quasarCapacityAfterClaim).to.be.bignumber.equal(expectedQuasarCapacity);
+
+                                    const { owedAmount } = await this.quasar.tokenData(ETH);
+                                    const { outputValue } = await this.quasar.ticketData(this.depositUtxoPos);
+
+                                    expect(owedAmount).to.be.bignumber.equal(outputValue);
+                                });
+
+                                it('should update the projected pool supply to include the fee', async () => {
+                                    const { poolSupply: poolSupplyAfterClaim, quasarFee } = await this.quasar.tokenData(
+                                        ETH,
+                                    );
+                                    const expectedPoolSupply = this.poolSupplyBeforeClaim.add(quasarFee);
+
+                                    expect(poolSupplyAfterClaim).to.be.bignumber.equal(expectedPoolSupply);
+                                });
+
+                                it('should update the exchange Rate for ETH', async () => {
+                                    const { exchangeRate: exchangeRateAfterClaim } = await this.quasar.tokenData(ETH);
+
+                                    expect(exchangeRateAfterClaim).to.be.bignumber.above(this.exchangeRateBeforeClaim);
+                                });
+
+                                describe('When the quasar Maintainer repays the pool', () => {
+                                    before(async () => {
+                                        this.owedAmountBeforeRepayment = (await this.quasar.tokenData(ETH)).owedAmount;
+                                        await this.quasar.repayOwedToken(
+                                            ETH,
+                                            0,
+                                            { from: quasarMaintainer, value: this.owedAmountBeforeRepayment },
+                                        );
+                                    });
+
+                                    it('should clear the owed amount', async () => {
+                                        const { owedAmount: owedAmountAfterRepayment } = await this.quasar.tokenData(
+                                            ETH,
+                                        );
+
+                                        expect(owedAmountAfterRepayment).to.be.bignumber.equal(new BN(0));
+                                    });
+
+                                    describe('If both Bob and Carol now wish to withdraw funds from the pool', () => {
+                                        before(async () => {
+                                            this.bobBalanceBeforeWithdraw = new BN(await web3.eth.getBalance(bob));
+                                            this.carolBalanceBeforeWithdraw = new BN(await web3.eth.getBalance(carol));
+                                            this.bobQTokenBalance = await this.qEth.balanceOf(bob);
+                                            this.carolQTokenBalance = await this.qEth.balanceOf(carol);
+                                            this.bobWithdrawTx = await this.quasar.withdrawFunds(
+                                                ETH,
+                                                this.bobQTokenBalance,
+                                                { from: bob },
+                                            );
+
+                                            this.carolWithdrawTx = await this.quasar.withdrawFunds(
+                                                ETH,
+                                                this.carolQTokenBalance,
+                                                { from: carol },
+                                            );
+                                        });
+
+                                        it('should be able to withdraw all qTokens', async () => {
+                                            const bobQTokenBalanceAfterWithdraw = await this.qEth.balanceOf(bob);
+                                            const carolQTokenBalanceAfterWithdraw = await this.qEth.balanceOf(carol);
+
+                                            expect(bobQTokenBalanceAfterWithdraw).to.be.bignumber.equal(new BN(0));
+                                            expect(carolQTokenBalanceAfterWithdraw).to.be.bignumber.equal(new BN(0));
+                                        });
+
+                                        it('should update the quasar capacity and balance', async () => {
+                                            const quasarCapacityAfterWithdraw = new BN(
+                                                await this.quasar.tokenUsableCapacity(ETH),
+                                            );
+                                            const quasarBalance = new BN(
+                                                await web3.eth.getBalance(this.quasar.address),
+                                            );
+                                            const { poolSupply } = await this.quasar.tokenData(ETH);
+
+                                            expect(quasarCapacityAfterWithdraw).to.be.bignumber.equal(
+                                                quasarBalance,
+                                            ).equal(poolSupply);
+                                            expect(quasarBalance).to.be.bignumber.at.most(
+                                                new BN(10),
+                                            ).at.least(new BN(0));
+                                        });
+
+                                        it('should distribute returns in accordance with the supplied amount', async () => {
+                                            const bobBalanceAfterWithdraw = new BN(await web3.eth.getBalance(bob));
+                                            const carolBalanceAfterWithdraw = new BN(await web3.eth.getBalance(carol));
+
+                                            const bobReturnProfit = bobBalanceAfterWithdraw.add(
+                                                await spentOnGas(this.bobWithdrawTx.receipt),
+                                            ).sub(this.bobBalanceBeforeWithdraw).subn(this.bobSuppliedFunds);
+
+                                            const carolReturnProfit = carolBalanceAfterWithdraw.add(
+                                                await spentOnGas(this.carolWithdrawTx.receipt),
+                                            ).sub(this.carolBalanceBeforeWithdraw).subn(this.carolSuppliedFunds);
+
+                                            expect(carolReturnProfit).be.bignumber.above(bobReturnProfit);
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+
+                /**
+                 * Scenario -
+                 * Bob and Carol supply ETH to the pool
+                 * After one round of claim, Bob withdraws and Dave supplies
+                 * After second round of claim, Dave and Carol both withdraw
+                */
+                describe('Scenario: Three suppliers, different entry point', () => {
+                    describe('When Bob and Carol supply ETH to the pool', () => {
+                        before(async () => {
+                            this.quasarCapacityBeforeAddingFunds = new BN(await this.quasar.tokenUsableCapacity(ETH));
+                            this.poolSupply = (await this.quasar.tokenData(ETH)).poolSupply;
+                            this.quasarBalance = new BN(await web3.eth.getBalance(this.quasar.address));
+                            this.bobSuppliedFunds = 1000000;
+                            this.carolSuppliedFunds = 1000000;
+                            this.daveSuppliedFunds = 1000000;
+                            await this.quasar.addEthCapacity({ from: bob, value: this.bobSuppliedFunds });
+                            await this.quasar.addEthCapacity({ from: carol, value: this.carolSuppliedFunds });
+                        });
+
+                        it('should update the quasar capacity', async () => {
+                            const quasarCapacityAfterAddingFunds = new BN(await this.quasar.tokenUsableCapacity(ETH));
+
+                            const expectedQuasarCapacity = this.quasarCapacityBeforeAddingFunds.addn(
+                                this.bobSuppliedFunds,
+                            ).addn(this.carolSuppliedFunds);
+                            expect(quasarCapacityAfterAddingFunds).to.be.bignumber.equal(expectedQuasarCapacity);
+                        });
+
+                        describe('When Alice obtains a ticket and claims', () => {
+                            before(async () => {
+                                await aliceDepositsETH();
+                                await submitPlasmaBlock();
+                                await submitPlasmaBlock();
+
+                                // Submit abother block for the safe margin
+                                const utxoPos = this.depositUtxoPos;
+                                const rlpOutputCreationTx = this.depositTx;
+                                const outputCreationTxInclusionProof = this.merkleProofForDepositTx;
+                                this.quasarCapacityBeforeTicket = new BN(await this.quasar.tokenUsableCapacity(ETH));
+                                await this.quasar.obtainTicket(
+                                    utxoPos,
+                                    rlpOutputCreationTx,
+                                    outputCreationTxInclusionProof,
+                                    {
+                                        from: alice,
+                                        value: this.dummyQuasarBondValue,
+                                    },
+                                );
+                                await aliceTransferEth(quasarOwner, DEPOSIT_VALUE);
+                                const utxoPosQuasarOwner = this.transferUtxoPos;
+                                const rlpTxToQuasarOwner = this.transferTx;
+                                const txToQuasarOwnerInclusionProof = this.merkleProofForTransferTx;
+
+                                this.aliceBalanceBeforeClaim = new BN(
+                                    await web3.eth.getBalance(alice),
+                                );
+                                this.reservedAmount = (await this.quasar.ticketData(utxoPos)).reservedAmount;
+                                this.poolSupplyBeforeClaim = (await this.quasar.tokenData(ETH)).poolSupply;
+                                this.exchangeRateBeforeClaim = (await this.quasar.tokenData(ETH)).exchangeRate;
+
+                                const { receipt } = await this.quasar.claim(
+                                    utxoPos,
+                                    utxoPosQuasarOwner,
+                                    rlpTxToQuasarOwner,
+                                    txToQuasarOwnerInclusionProof,
+                                    {
+                                        from: alice,
+                                    },
+                                );
+                                this.claimReceipt = receipt;
+                            });
+
+                            describe('And then Bob Withdraws and Dave supplies', () => {
+                                before(async () => {
+                                    this.quasarPoolSupplyBeforeWithdraw = (await this.quasar.tokenData(ETH)).poolSupply;
+                                    this.bobQTokenBalance = await this.qEth.balanceOf(bob);
+                                    this.bobBalanceBeforeWithdraw = new BN(await web3.eth.getBalance(bob));
+                                    this.bobWithdrawTx = await this.quasar.withdrawFunds(
+                                        ETH,
+                                        this.bobQTokenBalance,
+                                        { from: bob },
+                                    );
+                                    await this.quasar.addEthCapacity({ from: dave, value: this.daveSuppliedFunds });
+                                });
+
+                                it('should update Bob\'s qToken Balance', async () => {
+                                    const bobQTokenBalanceAfterWithdraw = await this.qEth.balanceOf(bob);
+
+                                    expect(bobQTokenBalanceAfterWithdraw).to.be.bignumber.equal(new BN(0));
+                                });
+
+                                it('should update the quasar supply and capacity', async () => {
+                                    const quasarCapacityAfterWithdraw = new BN(
+                                        await this.quasar.tokenUsableCapacity(ETH),
+                                    );
+                                    const quasarPoolSupplyAfterWithdraw = (await this.quasar.tokenData(ETH)).poolSupply;
+                                    const expectedPoolSupply = quasarCapacityAfterWithdraw.add(
+                                        (await this.quasar.tokenData(ETH)).owedAmount,
+                                    );
+
+                                    expect(expectedPoolSupply).to.be.bignumber.equal(quasarPoolSupplyAfterWithdraw)
+                                        .not.equal(this.quasarPoolSupplyBeforeWithdraw);
+                                });
+
+                                describe('And When another ticket is claimed', () => {
+                                    before(async () => {
+                                        await aliceDepositsETH();
+                                        await submitPlasmaBlock();
+                                        await submitPlasmaBlock();
+
+                                        // Submit abother block for the safe margin
+                                        const utxoPos = this.depositUtxoPos;
+                                        const rlpOutputCreationTx = this.depositTx;
+                                        const outputCreationTxInclusionProof = this.merkleProofForDepositTx;
+                                        this.quasarCapacityBeforeTicket = new BN(
+                                            await this.quasar.tokenUsableCapacity(ETH),
+                                        );
+                                        await this.quasar.obtainTicket(
+                                            utxoPos,
+                                            rlpOutputCreationTx,
+                                            outputCreationTxInclusionProof,
+                                            {
+                                                from: alice,
+                                                value: this.dummyQuasarBondValue,
+                                            },
+                                        );
+                                        await aliceTransferEth(quasarOwner, DEPOSIT_VALUE);
+                                        const utxoPosQuasarOwner = this.transferUtxoPos;
+                                        const rlpTxToQuasarOwner = this.transferTx;
+                                        const txToQuasarOwnerInclusionProof = this.merkleProofForTransferTx;
+
+                                        this.aliceBalanceBeforeClaim = new BN(
+                                            await web3.eth.getBalance(alice),
+                                        );
+                                        this.reservedAmount = (await this.quasar.ticketData(utxoPos)).reservedAmount;
+                                        this.poolSupplyBeforeClaim = (await this.quasar.tokenData(ETH)).poolSupply;
+                                        this.exchangeRateBeforeClaim = (await this.quasar.tokenData(ETH)).exchangeRate;
+
+                                        const { receipt } = await this.quasar.claim(
+                                            utxoPos,
+                                            utxoPosQuasarOwner,
+                                            rlpTxToQuasarOwner,
+                                            txToQuasarOwnerInclusionProof,
+                                            {
+                                                from: alice,
+                                            },
+                                        );
+                                        this.claimReceipt = receipt;
+                                    });
+
+                                    describe('And then the quasar Maintainer repays owed funds', () => {
+                                        before(async () => {
+                                            this.owedAmountBeforeRepayment = (await this.quasar.tokenData(
+                                                ETH,
+                                            )).owedAmount;
+                                            await this.quasar.repayOwedToken(
+                                                ETH,
+                                                0,
+                                                { from: quasarMaintainer, value: this.owedAmountBeforeRepayment },
+                                            );
+                                        });
+
+                                        describe('If both Carol and Dave now wish to withdraw funds from the pool', () => {
+                                            before(async () => {
+                                                this.carolBalanceBeforeWithdraw = new BN(
+                                                    await web3.eth.getBalance(carol),
+                                                );
+                                                this.daveBalanceBeforeWithdraw = new BN(
+                                                    await web3.eth.getBalance(dave),
+                                                );
+                                                const carolQTokenBalance = await this.qEth.balanceOf(carol);
+                                                this.carolWithdrawTx = await this.quasar.withdrawFunds(
+                                                    ETH,
+                                                    carolQTokenBalance,
+                                                    { from: carol },
+                                                );
+                                                const daveQTokenBalance = await this.qEth.balanceOf(dave);
+                                                this.daveWithdrawTx = await this.quasar.withdrawFunds(
+                                                    ETH,
+                                                    daveQTokenBalance,
+                                                    { from: dave },
+                                                );
+                                            });
+
+                                            it('should be able to withdraw all qTokens', async () => {
+                                                const carolQTokenBalanceAfterWithdraw = await this.qEth.balanceOf(
+                                                    carol,
+                                                );
+                                                const daveQTokenBalanceAfterWithdraw = await this.qEth.balanceOf(
+                                                    dave,
+                                                );
+
+                                                expect(carolQTokenBalanceAfterWithdraw).to.be.bignumber.equal(
+                                                    new BN(0),
+                                                );
+                                                expect(daveQTokenBalanceAfterWithdraw).to.be.bignumber.equal(
+                                                    new BN(0),
+                                                );
+                                            });
+
+                                            it('should update the quasar capacity and balance', async () => {
+                                                const quasarCapacityAfterWithdraw = new BN(
+                                                    await this.quasar.tokenUsableCapacity(ETH),
+                                                );
+                                                const quasarBalance = new BN(
+                                                    await web3.eth.getBalance(this.quasar.address),
+                                                );
+                                                const { poolSupply } = await this.quasar.tokenData(ETH);
+
+                                                expect(quasarCapacityAfterWithdraw).to.be.bignumber.equal(
+                                                    quasarBalance,
+                                                ).equal(poolSupply);
+                                                expect(quasarBalance).to.be.bignumber.at.most(
+                                                    new BN(10),
+                                                ).at.least(new BN(0));
+                                            });
+
+                                            it('should distribute returns in accordance with time', async () => {
+                                                const bobBalanceAfterWithdraw = new BN(
+                                                    await web3.eth.getBalance(bob),
+                                                );
+                                                const carolBalanceAfterWithdraw = new BN(
+                                                    await web3.eth.getBalance(carol),
+                                                );
+                                                const daveBalanceAfterWithdraw = new BN(
+                                                    await web3.eth.getBalance(dave),
+                                                );
+
+                                                const bobReturnProfit = bobBalanceAfterWithdraw.add(
+                                                    await spentOnGas(this.bobWithdrawTx.receipt),
+                                                ).sub(this.bobBalanceBeforeWithdraw).subn(this.bobSuppliedFunds);
+
+                                                const carolReturnProfit = carolBalanceAfterWithdraw.add(
+                                                    await spentOnGas(this.carolWithdrawTx.receipt),
+                                                ).sub(this.carolBalanceBeforeWithdraw).subn(this.carolSuppliedFunds);
+
+                                                const daveReturnProfit = daveBalanceAfterWithdraw.add(
+                                                    await spentOnGas(this.daveWithdrawTx.receipt),
+                                                ).sub(this.daveBalanceBeforeWithdraw).subn(this.daveSuppliedFunds);
+
+                                                expect(carolReturnProfit).be.bignumber.above(bobReturnProfit);
+                                                expect(carolReturnProfit).be.bignumber.above(daveReturnProfit);
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+
+                /**
+                 * Scenario -
+                 * Bob and Carol supply erc20 to the pool
+                 * After one round of (IFE) claim, Bob withdraws some qTokens
+                 * After second round of claim, Bob and Carol withdraw all tokens
+                */
+                describe('Scenario: Three suppliers, different amount and entry point', () => {
+                    describe('When Bob and Carol supply ERC20 to the pool', () => {
+                        before(async () => {
+                            await this.framework.addExitQueue(config.registerKeys.vaultId.erc20, this.erc20.address);
+
+                            this.quasarCapacityBeforeAddingFunds = new BN(
+                                await this.quasar.tokenUsableCapacity(this.erc20.address),
+                            );
+                            this.bobSuppliedERC20Funds = 1000000;
+                            this.carolSuppliedERC20Funds = 2000000;
+
+                            await this.erc20.transfer(bob, this.bobSuppliedERC20Funds, { from: richDad });
+                            await this.erc20.approve(this.quasar.address, this.bobSuppliedERC20Funds, { from: bob });
+                            await this.quasar.addTokenCapacity(
+                                this.erc20.address, this.bobSuppliedERC20Funds, { from: bob },
+                            );
+
+                            await this.erc20.transfer(carol, this.carolSuppliedERC20Funds, { from: richDad });
+                            await this.erc20.approve(
+                                this.quasar.address,
+                                this.carolSuppliedERC20Funds,
+                                { from: carol },
+                            );
+                            await this.quasar.addTokenCapacity(
+                                this.erc20.address, this.carolSuppliedERC20Funds, { from: carol },
+                            );
+                        });
+
+                        it('should increase the capacity of the Quasar', async () => {
+                            this.quasarCapacityAfterAddingFunds = new BN(
+                                await this.quasar.tokenUsableCapacity(this.erc20.address),
+                            );
+                            const quasarExpectedCapacity = this.quasarCapacityBeforeAddingFunds.addn(
+                                this.bobSuppliedERC20Funds,
+                            ).addn(this.carolSuppliedERC20Funds);
+
+                            expect(this.quasarCapacityAfterAddingFunds).to.be.bignumber.equal(
+                                quasarExpectedCapacity,
+                            );
+
+                            const quasarPoolSupply = (await this.quasar.tokenData(this.erc20.address)).poolSupply;
+                            const { owedAmount } = await this.quasar.tokenData(this.erc20.address);
+                            expect(quasarPoolSupply).to.be.bignumber.equal(
+                                this.quasarCapacityAfterAddingFunds.add(owedAmount),
+                            );
+                        });
+
+                        describe('When Alice obtains a ticket and ife claims', () => {
+                            before(async () => {
+                                await this.erc20.transfer(alice, DEPOSIT_VALUE, { from: richDad });
+                                await this.erc20.approve(this.erc20Vault.address, DEPOSIT_VALUE, { from: alice });
+                                await aliceDepositsErc20();
+                                await submitPlasmaBlock();
+                                await submitPlasmaBlock();
+
+                                const utxoPos = this.depositUtxoPos;
+                                const rlpOutputCreationTx = this.depositTx;
+                                const outputCreationTxInclusionProof = this.merkleProofForDepositTx;
+                                await this.quasar.obtainTicket(
+                                    utxoPos,
+                                    rlpOutputCreationTx,
+                                    outputCreationTxInclusionProof,
+                                    {
+                                        from: alice,
+                                        value: this.dummyQuasarBondValue,
+                                    },
+                                );
+
+                                await aliceTransferErc20(quasarOwner, DEPOSIT_VALUE);
+
+                                const inputTxs = [this.depositTx];
+                                const inputUtxosPos = [this.depositUtxoPos];
+                                const inputTxsInclusionProofs = [this.merkleProofForDepositTx];
+
+                                const txHash = hashTx(this.transferTxObject, this.framework.address);
+                                const signature = sign(txHash, alicePrivateKey);
+
+                                const args = {
+                                    inFlightTx: this.transferTx,
+                                    inputTxs,
+                                    inputUtxosPos,
+                                    inputTxsInclusionProofs,
+                                    inFlightTxWitnesses: [signature],
+                                };
+
+                                await this.exitGame.startInFlightExit(
+                                    args,
+                                    { from: alice, value: this.startIFEBondSize },
+                                );
+
+                                const rlpTxToQuasarOwner = this.transferTx;
+
+                                await this.quasar.ifeClaim(
+                                    utxoPos,
+                                    rlpTxToQuasarOwner,
+                                    {
+                                        from: alice,
+                                    },
+                                );
+
+                                this.exitingOutputIndex = 0;
+                                this.reservedAmount = (await this.quasar.ticketData(utxoPos)).reservedAmount;
+                                const piggybackArgs = {
+                                    inFlightTx: this.transferTx,
+                                    outputIndex: this.exitingOutputIndex,
+                                };
+
+                                this.piggybackTx = await this.exitGame.piggybackInFlightExitOnOutput(
+                                    piggybackArgs,
+                                    { from: quasarOwner, value: this.piggybackBondSize },
+                                );
+
+                                await time.increase(time.duration.seconds(this.ifeWaitingPeriod).add(
+                                    time.duration.seconds(1),
+                                ));
+
+                                await this.quasar.processIfeClaim(utxoPos);
+                            });
+
+                            it('should update the quasar capacity', async () => {
+                                const quasarCapacityAfterClaim = new BN(
+                                    await this.quasar.tokenUsableCapacity(this.erc20.address),
+                                );
+                                const expectedQuasarCapacity = this.quasarCapacityAfterAddingFunds.sub(
+                                    this.reservedAmount,
+                                );
+
+                                expect(quasarCapacityAfterClaim).to.be.bignumber.equal(expectedQuasarCapacity);
+                            });
+
+                            describe('And then Bob withdraws half of the qtokens after the pool is repayed', () => {
+                                before(async () => {
+                                    this.owedAmountBeforeRepayment = (await this.quasar.tokenData(ETH)).owedAmount;
+                                    await this.quasar.repayOwedToken(
+                                        ETH,
+                                        0,
+                                        { from: quasarMaintainer, value: this.owedAmountBeforeRepayment },
+                                    );
+
+                                    this.bobBalanceBeforeWithdraw = await this.erc20.balanceOf(bob);
+                                    this.bobQTokenBalance = await this.qErc20.balanceOf(bob);
+                                    this.withdrawTokens = new BN((this.bobQTokenBalance / 2).toFixed());
+                                    this.bobWithdrawTx = await this.quasar.withdrawFunds(
+                                        this.erc20.address,
+                                        this.withdrawTokens,
+                                        { from: bob },
+                                    );
+                                });
+
+                                it('should update Bob\'s qToken Balance', async () => {
+                                    const bobQTokenBalanceAfterWithdraw = await this.qErc20.balanceOf(bob);
+
+                                    expect(bobQTokenBalanceAfterWithdraw).to.be.bignumber.equal(
+                                        this.bobQTokenBalance.sub(this.withdrawTokens),
+                                    );
+                                });
+
+                                describe('And When another ticket is claimed', () => {
+                                    before(async () => {
+                                        await this.erc20.transfer(alice, DEPOSIT_VALUE, { from: richDad });
+                                        await this.erc20.approve(
+                                            this.erc20Vault.address,
+                                            DEPOSIT_VALUE,
+                                            { from: alice },
+                                        );
+                                        await aliceDepositsErc20();
+                                        await submitPlasmaBlock();
+                                        await submitPlasmaBlock();
+
+                                        // Submit abother block for the safe margin
+                                        const utxoPos = this.depositUtxoPos;
+                                        const rlpOutputCreationTx = this.depositTx;
+                                        const outputCreationTxInclusionProof = this.merkleProofForDepositTx;
+
+                                        await this.quasar.obtainTicket(
+                                            utxoPos,
+                                            rlpOutputCreationTx,
+                                            outputCreationTxInclusionProof,
+                                            {
+                                                from: alice,
+                                                value: this.dummyQuasarBondValue,
+                                            },
+                                        );
+                                        await aliceTransferErc20(quasarOwner, DEPOSIT_VALUE);
+                                        const utxoPosQuasarOwner = this.transferUtxoPos;
+                                        const rlpTxToQuasarOwner = this.transferTx;
+                                        const txToQuasarOwnerInclusionProof = this.merkleProofForTransferTx;
+
+                                        this.aliceBalanceBeforeClaim = new BN(
+                                            await web3.eth.getBalance(alice),
+                                        );
+                                        this.reservedAmount = (await this.quasar.ticketData(utxoPos)).reservedAmount;
+
+                                        const { receipt } = await this.quasar.claim(
+                                            utxoPos,
+                                            utxoPosQuasarOwner,
+                                            rlpTxToQuasarOwner,
+                                            txToQuasarOwnerInclusionProof,
+                                            {
+                                                from: alice,
+                                            },
+                                        );
+                                        this.claimReceipt = receipt;
+                                    });
+
+                                    describe('And then the quasar Maintainer repays owed funds', () => {
+                                        before(async () => {
+                                            this.owedAmountBeforeRepayment = (await this.quasar.tokenData(
+                                                this.erc20.address,
+                                            )).owedAmount;
+                                            await this.erc20.transfer(
+                                                quasarMaintainer,
+                                                this.owedAmountBeforeRepayment,
+                                                { from: richDad },
+                                            );
+                                            await this.erc20.approve(
+                                                this.quasar.address,
+                                                this.owedAmountBeforeRepayment,
+                                                { from: quasarMaintainer },
+                                            );
+                                            await this.quasar.repayOwedToken(
+                                                this.erc20.address,
+                                                this.owedAmountBeforeRepayment,
+                                                { from: quasarMaintainer },
+                                            );
+                                        });
+
+                                        describe('If both Bob and Carol now wish to withdraw all funds from the pool', () => {
+                                            before(async () => {
+                                                this.carolBalanceBeforeWithdraw = await this.erc20.balanceOf(carol);
+                                                this.qMaintainerBalanceBeforeWithdraw = await this.erc20.balanceOf(
+                                                    quasarMaintainer,
+                                                );
+
+                                                const bobQTokenBalance = await this.qErc20.balanceOf(bob);
+                                                this.bobWithdrawTx = await this.quasar.withdrawFunds(
+                                                    this.erc20.address,
+                                                    bobQTokenBalance,
+                                                    { from: bob },
+                                                );
+                                                const carolQTokenBalance = await this.qErc20.balanceOf(carol);
+                                                this.carolWithdrawTx = await this.quasar.withdrawFunds(
+                                                    this.erc20.address,
+                                                    carolQTokenBalance,
+                                                    { from: carol },
+                                                );
+
+                                                const quasarMaintainerQTokenBalance = await this.qErc20.balanceOf(
+                                                    quasarMaintainer,
+                                                );
+                                                this.qMaintainerWithdrawTx = await this.quasar.withdrawFunds(
+                                                    this.erc20.address,
+                                                    quasarMaintainerQTokenBalance,
+                                                    { from: quasarMaintainer },
+                                                );
+                                            });
+
+                                            it('should be able to withdraw all qTokens', async () => {
+                                                const bobQTokenBalAfterWithdraw = await this.qErc20.balanceOf(bob);
+                                                const carolQTokenBalAfterWithdraw = await this.qErc20.balanceOf(carol);
+                                                const qMaintainerQTokenBalAfterWithdraw = await this.qErc20.balanceOf(
+                                                    quasarMaintainer,
+                                                );
+
+                                                expect(bobQTokenBalAfterWithdraw).to.be.bignumber.equal(
+                                                    new BN(0),
+                                                );
+                                                expect(carolQTokenBalAfterWithdraw).to.be.bignumber.equal(
+                                                    new BN(0),
+                                                );
+                                                expect(qMaintainerQTokenBalAfterWithdraw).to.be.bignumber.equal(
+                                                    new BN(0),
+                                                );
+                                            });
+
+                                            it('should update the quasar capacity and balance', async () => {
+                                                const quasarCapacityAfterWithdraw = new BN(
+                                                    await this.quasar.tokenUsableCapacity(this.erc20.address),
+                                                );
+                                                const { poolSupply } = await this.quasar.tokenData(this.erc20.address);
+
+                                                expect(quasarCapacityAfterWithdraw).to.be.bignumber.equal(poolSupply);
+                                                expect(quasarCapacityAfterWithdraw).to.be.bignumber.at.most(
+                                                    new BN(10),
+                                                ).at.least(new BN(0));
+                                            });
+
+                                            it('should distribute returns in accordance with the supplied amount', async () => {
+                                                const bobBalanceAfterWithdraw = await this.erc20.balanceOf(bob);
+                                                const carolBalanceAfterWithdraw = await this.erc20.balanceOf(carol);
+                                                const qMaintainerBalanceAfterWithdraw = await this.erc20.balanceOf(
+                                                    quasarMaintainer,
+                                                );
+
+                                                const bobReturnProfit = bobBalanceAfterWithdraw.sub(
+                                                    this.bobBalanceBeforeWithdraw,
+                                                ).subn(this.bobSuppliedERC20Funds);
+
+                                                const carolReturnProfit = carolBalanceAfterWithdraw.sub(
+                                                    this.carolBalanceBeforeWithdraw,
+                                                ).subn(this.carolSuppliedERC20Funds);
+
+                                                const qMaintainerReturnProfit = qMaintainerBalanceAfterWithdraw.sub(
+                                                    this.qMaintainerBalanceBeforeWithdraw,
+                                                ).subn(QUASAR_LIQUID_FUNDS);
+
+                                                expect(qMaintainerReturnProfit).to.be.bignumber.above(
+                                                    carolReturnProfit,
+                                                );
+                                                expect(carolReturnProfit).to.be.bignumber.above(
+                                                    bobReturnProfit,
                                                 );
                                             });
                                         });

--- a/plasma_framework/test/src/poc/fast_exits/QuasarPool.test.js
+++ b/plasma_framework/test/src/poc/fast_exits/QuasarPool.test.js
@@ -1,0 +1,134 @@
+/* eslint-disable no-await-in-loop */
+const Quasar = artifacts.require('QuasarPoolMock');
+const QToken = artifacts.require('QToken');
+const ERC20Mintable = artifacts.require('ERC20Mintable');
+const SpyPlasmaFramework = artifacts.require('SpyPlasmaFrameworkForExitGame');
+const SpendingConditionMock = artifacts.require('SpendingConditionMock');
+const SpendingConditionRegistry = artifacts.require('SpendingConditionRegistry');
+
+const { BN, constants } = require('openzeppelin-test-helpers');
+const { expect } = require('chai');
+const { TX_TYPE, OUTPUT_TYPE } = require('../../../helpers/constants.js');
+
+contract('Quasar Pool', ([authority, quasarOwner, quasarMaintainer, supplierOne, supplierTwo, supplierThree, supplierFour, supplierFive]) => {
+    const MIN_EXIT_PERIOD = 10;
+    const INITIAL_IMMUNE_VAULTS = 1;
+    const INITIAL_IMMUNE_EXIT_GAME = 1;
+    const SAFE_BLOCK_MARGIN = 10;
+    const WAITING_PERIOD = 3600;
+    const BOND_VALUE = 100;
+    const ETH = constants.ZERO_ADDRESS;
+
+    const randomNum = (min, max) => Math.floor(Math.random() * (max - min + 1) + min);
+
+    const setupAllContracts = async () => {
+        this.plasmaFramework = await SpyPlasmaFramework.new(
+            MIN_EXIT_PERIOD,
+            INITIAL_IMMUNE_VAULTS,
+            INITIAL_IMMUNE_EXIT_GAME,
+            { from: authority },
+        );
+        this.plasmaFramework.activateChildChain({ from: authority });
+        this.childBlockInterval = await this.plasmaFramework.childBlockInterval();
+        // Submit some blocks to have a safe block margin
+        const DUMMY_BLOCK_HASH = web3.utils.sha3('dummy root');
+        for (let i = 0; i < SAFE_BLOCK_MARGIN; i++) {
+            await this.plasmaFramework.submitBlock(DUMMY_BLOCK_HASH, { from: authority });
+        }
+
+        this.spendingConditionRegistry = await SpendingConditionRegistry.new();
+        this.spendingCondition = await SpendingConditionMock.new();
+        // lets the spending condition pass by default
+        await this.spendingCondition.mockResult(true);
+        await this.spendingConditionRegistry.registerSpendingCondition(
+            OUTPUT_TYPE.PAYMENT, TX_TYPE.PAYMENT, this.spendingCondition.address,
+        );
+        this.erc20 = await ERC20Mintable.new();
+
+        this.quasar = await Quasar.new(
+            this.plasmaFramework.address,
+            this.spendingConditionRegistry.address,
+            quasarOwner,
+            SAFE_BLOCK_MARGIN,
+            WAITING_PERIOD,
+            BOND_VALUE,
+            { from: quasarMaintainer },
+        );
+
+        this.qEth = await QToken.new('Quasar Ether', 'qETH', 18, this.quasar.address);
+        await this.quasar.registerQToken(
+            ETH,
+            this.qEth.address,
+            5000,
+            { from: quasarMaintainer },
+        );
+
+        this.feeEth = (await this.quasar.tokenData(ETH)).quasarFee;
+    };
+
+    describe('Randomised Supply/Withdraw Flow', () => {
+        before(setupAllContracts);
+
+        describe('Supply/Withdraw Eth in between a random number of fee cycles', () => {
+            before(async () => {
+                const FEE_CYCLES = randomNum(50, 150);
+                this.suppliers = [supplierOne, supplierTwo, supplierThree, supplierFour, supplierFive];
+
+                for (let i = 0; i < FEE_CYCLES; i++) {
+                    let noOfDepositors = randomNum(0, 5);
+
+                    // if this is first round ensure at least one supplier
+                    if (i === 0 && noOfDepositors === 0) {
+                        noOfDepositors += 1;
+                    }
+
+                    // supply amount
+                    for (let j = 0; j < noOfDepositors; j++) {
+                        const amount = randomNum(40000000000000, 1230000000000000);
+                        await this.quasar.addEthCapacity({ from: this.suppliers[j], value: amount });
+                    }
+
+                    if (noOfDepositors >= 2) {
+                        const noOfWithdrawers = randomNum(0, noOfDepositors - 2);
+                        for (let k = 0; k < noOfWithdrawers; k++) {
+                            const supplierNumber = randomNum(0, noOfDepositors - 1);
+
+                            // supplier[supplierNumber] withdraws
+                            const qEthBalance = await this.qEth.balanceOf(this.suppliers[supplierNumber]);
+                            await this.quasar.withdrawFunds(ETH, qEthBalance, { from: this.suppliers[supplierNumber] });
+                        }
+                    }
+
+                    // the funds from pool are utilized and then reapyed
+                    await this.quasar.utilizeQuasarPool(ETH, 0, { from: quasarOwner, value: this.feeEth });
+                }
+            });
+
+            it('expected Pool Balance equal to Contract Balance', async () => {
+                const contractBalance = new BN(await web3.eth.getBalance(this.quasar.address));
+                const { poolSupply: expectedPoolSupply } = await this.quasar.tokenData(ETH);
+
+                expect(contractBalance).to.be.bignumber.equal(expectedPoolSupply);
+            });
+
+            it('Allows everyone to get off pool with returns', async () => {
+                // Attempting to withdraw all Q Tokens from pool now
+                for (let i = 0; i < 5; i++) {
+                    const supplierBalance = await this.qEth.balanceOf(this.suppliers[i]);
+                    if (supplierBalance !== 0) {
+                        // supplier #(i+1) withdraws
+                        await this.quasar.withdrawFunds(ETH, supplierBalance, { from: this.suppliers[i] });
+                    }
+                }
+            });
+
+            it('No Residual qTokens', async () => {
+                const contractBalance = new BN(await web3.eth.getBalance(this.quasar.address));
+                /* eslint-disable no-console */
+                console.log('\nContract Balance: ', contractBalance.toString(), ' wei');
+                const contractQtokenBalance = await this.qEth.totalSupply();
+                expect(contractQtokenBalance).to.be.bignumber.equal(new BN(0));
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Key
#### output_value: 
actual size of output that has to be fast exited

#### reserved_amount:
amount that can be withdrawn from the pool with the above output ( output_value - fees)

#### token_usable_capacity:
--> addCapacity() increases capacity by `supplied_funds`
----> obtainTicket() decreases capacity by `reserved_amount`
------> flushTicket() increases capacity back by `reserved_amount`
------> challengeClaim() can increase capacity back by `reserved_amount`
else, withdrawal successful, capacity reduced
--> repayPool() increases capacity by `output_value` of claimed outputs ( fee + `reserved_amount`)

--> withdrawFunds() decreases capacity by `supplied_funds` + fee(accumulated), [up till value of usable_capacity]

#### unclaimed_bond_reserve:
--> obtainTicket() adds bond value to contract
----> flushExpiredTicket() adds bond to unclaimed_bond reserve (stays in the contract)
------> withdrawUnclaimedBonds() returns this store to quasar maintainer
----> challengeClaim() returns bond to challenger
----> claim (or) processClaim() returns bond to output owner

#### pool_supply:
for the calculation of exchange rate
--> addCapacity() increases supply by `supplied_funds`
--> Claim (or) processClaim() increases supply by fee
--> withdrawFunds() decrease supply by `supplied_funds` + fee(accumulated)

#### owed_amount:
--> claim (or) processClaim() increases owed by `output_value` of claimed output ( fee + `reserved_amount`)
--> repayPool() decreases owed by amount supplied