### PR TITLE
Kevin/quasar improvements

### DIFF
--- a/plasma_framework/contracts/mocks/quasar/QuasarPoolMock.sol
+++ b/plasma_framework/contracts/mocks/quasar/QuasarPoolMock.sol
@@ -9,7 +9,7 @@ contract QuasarPoolMock is Quasar {
         address plasmaFrameworkContract, 
         address spendingConditionRegistryContract, 
         address _quasarOwner, 
-        uint256 _safeBlockMargin, 
+        uint64 _safeBlockMargin, 
         uint256 _bondValue
     ) public Quasar(plasmaFrameworkContract, spendingConditionRegistryContract, _quasarOwner, _safeBlockMargin, _bondValue) {
     }

--- a/plasma_framework/contracts/quasar/Quasar.sol
+++ b/plasma_framework/contracts/quasar/Quasar.sol
@@ -54,7 +54,6 @@ contract Quasar is QuasarPool {
         uint256 outputValue;
         uint256 reservedAmount;
         address token;
-        uint256 bondValue;
         bytes rlpOutputCreationTx;
         bool isClaimed;
     }
@@ -134,7 +133,7 @@ contract Quasar is QuasarPool {
         ticketData[utxoPos].reservedAmount = 0;
         ticketData[utxoPos].validityTimestamp = 0;
         tokenUsableCapacity[ticketData[utxoPos].token] = tokenUsableCapacity[ticketData[utxoPos].token].add(tokenAmount);
-        unclaimedBonds = unclaimedBonds.add(ticketData[utxoPos].bondValue); 
+        unclaimedBonds = unclaimedBonds.add(bondValue); 
     }
 
     /**
@@ -202,7 +201,7 @@ contract Quasar is QuasarPool {
         require(reservedAmount <= tokenUsableCapacity[outputData.token], "Requested amount exceeds the Usable Liqudity");
 
         tokenUsableCapacity[outputData.token] = tokenUsableCapacity[outputData.token].sub(reservedAmount);
-        ticketData[utxoPos] = Ticket(msg.sender, block.timestamp.add(TICKET_VALIDITY_PERIOD), outputData.amount, reservedAmount, outputData.token, msg.value, rlpOutputCreationTx, false);
+        ticketData[utxoPos] = Ticket(msg.sender, block.timestamp.add(TICKET_VALIDITY_PERIOD), outputData.amount, reservedAmount, outputData.token, rlpOutputCreationTx, false);
         emit NewTicketObtained(utxoPos);
     }
 
@@ -310,7 +309,7 @@ contract Quasar is QuasarPool {
         ifeClaimData[utxoPos].isValid = false;
         Ticket memory ticket = ticketData[utxoPos];
         tokenUsableCapacity[ticket.token] = tokenUsableCapacity[ticket.token].add(ticket.reservedAmount);
-        SafeEthTransfer.transferRevertOnError(msg.sender, ticket.bondValue, SAFE_GAS_STIPEND);
+        SafeEthTransfer.transferRevertOnError(msg.sender, bondValue, SAFE_GAS_STIPEND);
     }
 
     /**
@@ -411,11 +410,11 @@ contract Quasar is QuasarPool {
     */
     function runPayout(uint256 utxoPos, address payable outputOwner, address token) private {
         if (token == address(0)) {
-            uint256 totalAmount = ticketData[utxoPos].reservedAmount.add(ticketData[utxoPos].bondValue);
+            uint256 totalAmount = ticketData[utxoPos].reservedAmount.add(bondValue);
             SafeEthTransfer.transferRevertOnError(outputOwner, totalAmount, SAFE_GAS_STIPEND);
         } else {
             IERC20(token).safeTransfer(outputOwner, ticketData[utxoPos].reservedAmount);
-            SafeEthTransfer.transferRevertOnError(outputOwner, ticketData[utxoPos].bondValue, SAFE_GAS_STIPEND);
+            SafeEthTransfer.transferRevertOnError(outputOwner, bondValue, SAFE_GAS_STIPEND);
         }
     }
 

--- a/plasma_framework/contracts/quasar/Quasar.sol
+++ b/plasma_framework/contracts/quasar/Quasar.sol
@@ -115,7 +115,7 @@ contract Quasar is QuasarPool {
      * @dev Set the safe block margin.
      * @param margin the new safe block margin
     */
-    function setSafeBlockMargin (uint256 margin) public onlyQuasarMaintainer() {
+    function setSafeBlockMargin (uint256 margin) external onlyQuasarMaintainer() {
         safeBlockMargin = margin;
     }
 
@@ -124,7 +124,7 @@ contract Quasar is QuasarPool {
      * @notice Only an unclaimed ticket can be flushed, bond amount is added to unclaimedBonds
      * @param utxoPos pos of the output, which is the ticket identifier
     */
-    function flushExpiredTicket(uint256 utxoPos) public {
+    function flushExpiredTicket(uint256 utxoPos) external {
         uint256 expiryTimestamp = ticketData[utxoPos].validityTimestamp;
         require(!ticketData[utxoPos].isClaimed, "The UTXO has already been claimed");
         require(block.timestamp > expiryTimestamp && expiryTimestamp != 0, "Ticket still valid or doesn't exist");
@@ -139,21 +139,21 @@ contract Quasar is QuasarPool {
     /**
      * @dev Pause contract in a byzantine state
     */
-    function pauseQuasar() public onlyQuasarMaintainer() {
+    function pauseQuasar() external onlyQuasarMaintainer() {
         isPaused = true;
     }
 
     /**
      * @dev Unpause contract and allow tickets
     */
-    function resumeQuasar() public onlyQuasarMaintainer() {
+    function resumeQuasar() external onlyQuasarMaintainer() {
         isPaused = false;
     }
 
     /**
      * @dev Withdraw Unclaimed bonds from the contract
     */
-    function withdrawUnclaimedBonds() public onlyQuasarMaintainer() {
+    function withdrawUnclaimedBonds() external onlyQuasarMaintainer() {
         uint256 amount = unclaimedBonds;
         unclaimedBonds = 0;
         SafeEthTransfer.transferRevertOnError(msg.sender, amount, SAFE_GAS_STIPEND);
@@ -316,7 +316,7 @@ contract Quasar is QuasarPool {
      * @dev Process the IFE claim to get liquid funds
      * @param utxoPos pos of the output, which is the ticket identifier
     */
-    function processIfeClaim(uint256 utxoPos) public {
+    function processIfeClaim(uint256 utxoPos) external {
         require(block.timestamp > ifeClaimData[utxoPos].finalizationTimestamp, "The claim is not finalized yet");
         require(ifeClaimData[utxoPos].isValid, "The claim has already been claimed or challenged");
         ifeClaimData[utxoPos].isValid = false;
@@ -347,7 +347,7 @@ contract Quasar is QuasarPool {
      * @param challengeTxInputIndex index pos of the same utxo in the challenge transaction
      * @param challengeTxWitness Witness for challenging transaction
     */
-    function verifySpendingCondition(uint256 utxoPos, bytes memory rlpOutputCreationTx, bytes memory rlpChallengeTx, uint16 challengeTxInputIndex, bytes memory challengeTxWitness) private {
+    function verifySpendingCondition(uint256 utxoPos, bytes memory rlpOutputCreationTx, bytes memory rlpChallengeTx, uint16 challengeTxInputIndex, bytes memory challengeTxWitness) private view {
         GenericTransaction.Transaction memory challengingTx = GenericTransaction.decode(rlpChallengeTx);
 
         GenericTransaction.Transaction memory inputTx = GenericTransaction.decode(rlpOutputCreationTx);
@@ -372,7 +372,7 @@ contract Quasar is QuasarPool {
      * @dev Verify the validity of the ticket
      * @param utxoPos pos of the output, which is the ticket identifier
     */
-    function verifyTicketValidityForClaim(uint256 utxoPos) private {
+    function verifyTicketValidityForClaim(uint256 utxoPos) private view {
         require(!ticketData[utxoPos].isClaimed, "Already claimed");
         require(ticketData[utxoPos].outputOwner == msg.sender, "Not called by the ticket owner");
         uint256 expiryTimestamp = ticketData[utxoPos].validityTimestamp;
@@ -384,7 +384,7 @@ contract Quasar is QuasarPool {
      * @param utxoPos pos of the output, which is the ticket identifier
      * @param claimTx the Claim Tx to the quasar owner
     */
-    function verifyClaimTxCorrectlyFormed(uint256 utxoPos, bytes memory claimTx) private {
+    function verifyClaimTxCorrectlyFormed(uint256 utxoPos, bytes memory claimTx) private view {
         PaymentTransactionModel.Transaction memory decodedTx
         = PaymentTransactionModel.decode(claimTx);
 

--- a/plasma_framework/contracts/quasar/Quasar.sol
+++ b/plasma_framework/contracts/quasar/Quasar.sol
@@ -2,6 +2,7 @@ pragma solidity 0.5.11;
 pragma experimental ABIEncoderV2;
 
 import "./QuasarPool.sol";
+import "./utils/TimelockedValue.sol";
 import "../src/framework/PlasmaFramework.sol";
 import "../src/exits/payment/PaymentExitGame.sol";
 import "../src/utils/PosLib.sol";
@@ -27,6 +28,7 @@ contract Quasar is QuasarPool {
     using SafeMath for uint256;
     using SafeMath for uint64;
     using PosLib for PosLib.Position;
+    using TimelockedValue for TimelockedValue.Params;
 
     PlasmaFramework public plasmaFramework;
     // This contract works with the current exit game
@@ -36,7 +38,8 @@ contract Quasar is QuasarPool {
     SpendingConditionRegistry public spendingConditionRegistry;
 
     address public quasarOwner;
-    uint256 public safeBlockMargin;
+    TimelockedValue.Params internal safeBlockMargin;
+
     uint256 constant public TICKET_VALIDITY_PERIOD = 14400;
     uint256 constant public IFE_CLAIM_MARGIN = 28800;
     // 7+1 days waiting period for IFE Claims
@@ -69,9 +72,10 @@ contract Quasar is QuasarPool {
 
     event NewTicketObtained(uint256 utxoPos);
     event IFEClaimSubmitted(uint256 utxoPos, uint160 exitId);
+    event SetSafeBlockMarginCalled(uint64 nextSafeBlockMargin);
 
     modifier onlyWhenNotPaused() {
-        require(!isPaused, "The Quasar contract is paused");
+        require(!isPaused, "Quasar paused");
         _;
     }
 
@@ -86,7 +90,7 @@ contract Quasar is QuasarPool {
         address plasmaFrameworkContract, 
         address spendingConditionRegistryContract, 
         address _quasarOwner, 
-        uint256 _safeBlockMargin, 
+        uint64 _safeBlockMargin, 
         uint256 _bondValue
     ) public {
         plasmaFramework = PlasmaFramework(plasmaFrameworkContract);
@@ -94,7 +98,7 @@ contract Quasar is QuasarPool {
         spendingConditionRegistry = SpendingConditionRegistry(spendingConditionRegistryContract);
         quasarOwner = _quasarOwner;
         quasarMaintainer = msg.sender;
-        safeBlockMargin = _safeBlockMargin;
+        safeBlockMargin = TimelockedValue.buildParams(_safeBlockMargin);
         bondValue = _bondValue;
         unclaimedBonds = 0;
     }
@@ -105,7 +109,7 @@ contract Quasar is QuasarPool {
     function getLatestSafeBlock() public view returns(uint256) {
         uint256 childBlockInterval = plasmaFramework.childBlockInterval();
         uint currentPlasmaBlock = plasmaFramework.nextChildBlock().sub(childBlockInterval);
-        return currentPlasmaBlock.sub(safeBlockMargin.mul(childBlockInterval));
+        return currentPlasmaBlock.sub(getSafeBlockMargin().mul(childBlockInterval));
     }
 
     ////////////////////////////////////////////	
@@ -115,8 +119,15 @@ contract Quasar is QuasarPool {
      * @dev Set the safe block margin.
      * @param margin the new safe block margin
     */
-    function setSafeBlockMargin (uint256 margin) external onlyQuasarMaintainer() {
-        safeBlockMargin = margin;
+    function setSafeBlockMargin (uint64 margin) external onlyQuasarMaintainer() {
+        safeBlockMargin.updateValue(margin);
+        emit SetSafeBlockMarginCalled(margin);
+    }
+
+    /**
+     */
+    function getSafeBlockMargin() public view returns (uint64) {
+        return safeBlockMargin.getValue();
     }
 
     /**
@@ -126,8 +137,8 @@ contract Quasar is QuasarPool {
     */
     function flushExpiredTicket(uint256 utxoPos) external {
         uint256 expiryTimestamp = ticketData[utxoPos].validityTimestamp;
-        require(!ticketData[utxoPos].isClaimed, "The UTXO has already been claimed");
-        require(block.timestamp > expiryTimestamp && expiryTimestamp != 0, "Ticket still valid or doesn't exist");
+        require(!ticketData[utxoPos].isClaimed, "Already claimed");
+        require(block.timestamp > expiryTimestamp && expiryTimestamp != 0, "Can't flush");
 
         uint256 tokenAmount = ticketData[utxoPos].reservedAmount;
         ticketData[utxoPos].reservedAmount = 0;
@@ -170,13 +181,13 @@ contract Quasar is QuasarPool {
      * @param outputCreationTxInclusionProof Transaction inclusion proof
     */
     function obtainTicket(uint256 utxoPos, bytes memory rlpOutputCreationTx, bytes memory outputCreationTxInclusionProof) public payable onlyWhenNotPaused() {
-        require(msg.value == bondValue, "Bond Value incorrect");
-        require(!ticketData[utxoPos].isClaimed, "The UTXO has already been claimed");
-        require(ticketData[utxoPos].validityTimestamp == 0, "This UTXO already has a ticket");
+        require(msg.value == bondValue, "Incorrect bond");
+        require(!ticketData[utxoPos].isClaimed, "Already claimed");
+        require(ticketData[utxoPos].validityTimestamp == 0, "Existing ticket");
 
         PosLib.Position memory utxoPosDecoded = PosLib.decode(utxoPos);
 
-        require(utxoPosDecoded.blockNum <= getLatestSafeBlock(), "The UTXO is from a block later than the safe limit");
+        require(utxoPosDecoded.blockNum <= getLatestSafeBlock(), "Later than safe limit");
 
         PaymentTransactionModel.Transaction memory decodedTx
         = PaymentTransactionModel.decode(rlpOutputCreationTx);
@@ -185,20 +196,20 @@ contract Quasar is QuasarPool {
         = PaymentTransactionModel.getOutput(decodedTx, utxoPosDecoded.outputIndex);
         
         // verify the owner of output is obtaining the ticket
-        require(verifyOwnership(outputData, msg.sender), "Was not called by the Output owner");
+        require(verifyOwnership(outputData, msg.sender), "Not called owner");
 
         require(MoreVpFinalization.isStandardFinalized(
             plasmaFramework,
             rlpOutputCreationTx,
             utxoPosDecoded.toStrictTxPos(),
             outputCreationTxInclusionProof
-        ), "Provided Tx doesn't exist");
+        ), "Tx doesn't exist");
 
         uint256 quasarFee = tokenData[outputData.token].quasarFee;
 
-        require(outputData.amount > quasarFee, "The UTXO isn't enough to cover the fee");
+        require(outputData.amount > quasarFee, "Insufficient fee");
         uint256 reservedAmount = outputData.amount.sub(quasarFee);
-        require(reservedAmount <= tokenUsableCapacity[outputData.token], "Requested amount exceeds the Usable Liqudity");
+        require(reservedAmount <= tokenUsableCapacity[outputData.token], "Insufficient liqudity");
 
         tokenUsableCapacity[outputData.token] = tokenUsableCapacity[outputData.token].sub(reservedAmount);
         ticketData[utxoPos] = Ticket(msg.sender, block.timestamp.add(TICKET_VALIDITY_PERIOD), outputData.amount, reservedAmount, outputData.token, rlpOutputCreationTx, false);
@@ -229,7 +240,7 @@ contract Quasar is QuasarPool {
             rlpTxToQuasarOwner,
             utxoQuasarOwnerDecoded.toStrictTxPos(),
             txToQuasarOwnerInclusionProof
-        ), "Provided Tx doesn't exist");
+        ), "Tx doesn't exist");
 
         ticketData[utxoPos].isClaimed = true;
 
@@ -253,11 +264,11 @@ contract Quasar is QuasarPool {
         uint160[] memory exitIdArr = new uint160[](1);
         exitIdArr[0] = exitId;
         PaymentExitDataModel.InFlightExit[] memory ifeData = paymentExitGame.inFlightExits(exitIdArr);
-        require(ifeData[0].exitStartTimestamp != 0, "IFE has not been started");
+        require(ifeData[0].exitStartTimestamp != 0, "IFE not started");
 
         // IFE claims should start within IFE_CLAIM_MARGIN from starting IFE to enable sufficient time to piggyback
         // this might be overriden by the ticket expiry check usually, except if the ticket is obtained later
-        require(block.timestamp <= ifeData[0].exitStartTimestamp.add(IFE_CLAIM_MARGIN), "IFE Claim period has passed");
+        require(block.timestamp <= ifeData[0].exitStartTimestamp.add(IFE_CLAIM_MARGIN), "Claim period passed");
 
         ticketData[utxoPos].isClaimed = true;
         ifeClaimData[utxoPos] = Claim(inFlightClaimTx, block.timestamp.add(IFE_CLAIM_WAITING_PERIOD), true);
@@ -285,17 +296,17 @@ contract Quasar is QuasarPool {
         bytes32 senderData
     ) public {
         require(senderData == keccak256(abi.encodePacked(msg.sender)), "Incorrect SenderData");
-        require(ticketData[utxoPos].isClaimed && ifeClaimData[utxoPos].isValid, "The claim is not challengeable");
+        require(ticketData[utxoPos].isClaimed && ifeClaimData[utxoPos].isValid, "Not challengeable");
         require(block.timestamp <= ifeClaimData[utxoPos].finalizationTimestamp, "The challenge period is over");
         require(
             keccak256(ifeClaimData[utxoPos].rlpClaimTx) != keccak256(rlpChallengeTx),
-            "The challenging transaction is the same as the claim transaction"
+            "Challenge tx == claim tx"
         );
 
         require(MoreVpFinalization.isProtocolFinalized(
             plasmaFramework,
             rlpChallengeTx
-        ), "The challenging transaction is invalid");
+        ), "Invalid challenge tx");
 
         if (otherInputCreationTx.length == 0) {
             verifySpendingCondition(utxoPos, ticketData[utxoPos].rlpOutputCreationTx, rlpChallengeTx, challengeTxInputIndex, challengeTxWitness);
@@ -317,8 +328,8 @@ contract Quasar is QuasarPool {
      * @param utxoPos pos of the output, which is the ticket identifier
     */
     function processIfeClaim(uint256 utxoPos) external {
-        require(block.timestamp > ifeClaimData[utxoPos].finalizationTimestamp, "The claim is not finalized yet");
-        require(ifeClaimData[utxoPos].isValid, "The claim has already been claimed or challenged");
+        require(block.timestamp > ifeClaimData[utxoPos].finalizationTimestamp, "Claim not finalized");
+        require(ifeClaimData[utxoPos].isValid, "Claim invalid");
         ifeClaimData[utxoPos].isValid = false;
 
         utilize(ticketData[utxoPos].token, ticketData[utxoPos].outputValue);
@@ -374,9 +385,9 @@ contract Quasar is QuasarPool {
     */
     function verifyTicketValidityForClaim(uint256 utxoPos) private view {
         require(!ticketData[utxoPos].isClaimed, "Already claimed");
-        require(ticketData[utxoPos].outputOwner == msg.sender, "Not called by the ticket owner");
+        require(ticketData[utxoPos].outputOwner == msg.sender, "Not owner");
         uint256 expiryTimestamp = ticketData[utxoPos].validityTimestamp;
-        require(expiryTimestamp != 0 && block.timestamp <= expiryTimestamp, "Ticket is not valid");
+        require(expiryTimestamp != 0 && block.timestamp <= expiryTimestamp, "Invalid ticket");
     }
     
     /**
@@ -389,17 +400,17 @@ contract Quasar is QuasarPool {
         = PaymentTransactionModel.decode(claimTx);
 
         // first input should be the Utxo with which ticket was obtained
-        require(decodedTx.inputs[0] == bytes32(utxoPos), "The claim transaction does not spend the correct output");
+        require(decodedTx.inputs[0] == bytes32(utxoPos), "Incorrect output");
 
         // first output should be the utxo for Quasar owner
         FungibleTokenOutputModel.Output memory outputData
         = PaymentTransactionModel.getOutput(decodedTx, 0);
 
         // verify output to Quasar Owner
-        require(verifyOwnership(outputData, quasarOwner), "The output is not owned by the quasar owner");
+        require(verifyOwnership(outputData, quasarOwner), "Output not sent to quasar owner");
         // considering fee as a separate input
-        require(ticketData[utxoPos].outputValue == outputData.amount, "Wrong amount sent to quasar owner");
-        require(ticketData[utxoPos].token == outputData.token, "Wrong token sent to quasar owner");
+        require(ticketData[utxoPos].outputValue == outputData.amount, "Wrong amount sent");
+        require(ticketData[utxoPos].token == outputData.token, "Wrong token sent");
     }
 
     /**

--- a/plasma_framework/contracts/quasar/QuasarPool.sol
+++ b/plasma_framework/contracts/quasar/QuasarPool.sol
@@ -7,8 +7,9 @@ import "./interfaces/IQToken.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
+import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
 
-contract QuasarPool is Exponential {
+contract QuasarPool is Exponential, ReentrancyGuard {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
@@ -47,7 +48,7 @@ contract QuasarPool is Exponential {
      * @param token the token
      * @param amount value to supply
     */
-    function addTokenCapacity(address token, uint256 amount) external {
+    function addTokenCapacity(address token, uint256 amount) external nonReentrant() {
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
         mintQTokens(token, amount);
@@ -76,7 +77,7 @@ contract QuasarPool is Exponential {
      * @param token the token
      * @param amount amount (in number of qTokens) to withdraw
     */
-    function withdrawFunds(address token, uint256 amount) external {
+    function withdrawFunds(address token, uint256 amount) external  nonReentrant(){
         address qToken = tokenData[token].qTokenAddress;
         uint256 qTokenBalance = IERC20(qToken).balanceOf(msg.sender);
         require(amount <= qTokenBalance, "Not enough qToken Balance");
@@ -117,7 +118,7 @@ contract QuasarPool is Exponential {
      * @param token the token
      * @param amount amount to repay
     */
-    function repayOwedToken(address token, uint256 amount) public payable {
+    function repayOwedToken(address token, uint256 amount) public payable nonReentrant() {
         if (token == address(0)) {
             amount = msg.value;
         } else {

--- a/plasma_framework/contracts/quasar/QuasarPool.sol
+++ b/plasma_framework/contracts/quasar/QuasarPool.sol
@@ -37,7 +37,7 @@ contract QuasarPool is Exponential {
      * Verify QToken contract before supplying
      * @dev Add Eth Liquid funds to the quasar
     */
-    function addEthCapacity() public payable {
+    function addEthCapacity() external payable {
         mintQTokens(address(0), msg.value);
     }
 
@@ -47,7 +47,7 @@ contract QuasarPool is Exponential {
      * @param token the token
      * @param amount value to supply
     */
-    function addTokenCapacity(address token, uint256 amount) public {
+    function addTokenCapacity(address token, uint256 amount) external {
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
         mintQTokens(token, amount);
@@ -76,7 +76,7 @@ contract QuasarPool is Exponential {
      * @param token the token
      * @param amount amount (in number of qTokens) to withdraw
     */
-    function withdrawFunds(address token, uint256 amount) public {
+    function withdrawFunds(address token, uint256 amount) external {
         address qToken = tokenData[token].qTokenAddress;
         uint256 qTokenBalance = IERC20(qToken).balanceOf(msg.sender);
         require(amount <= qTokenBalance, "Not enough qToken Balance");
@@ -107,7 +107,7 @@ contract QuasarPool is Exponential {
      * @param qTokenContract the address of the qToken contract
      * @param quasarFee amount (in token's denomination) to be used as a fee
     */
-    function registerQToken(address token, address qTokenContract, uint256 quasarFee) public onlyQuasarMaintainer() {
+    function registerQToken(address token, address qTokenContract, uint256 quasarFee) external onlyQuasarMaintainer() {
         require(tokenData[token].qTokenAddress == address(0), "QToken for the token already exists");
         tokenData[token] = Token(qTokenContract, INITIAL_EXCHANGE_RATE_SCALED, 0, 0, quasarFee);
     }

--- a/plasma_framework/contracts/quasar/utils/TimelockedValue.sol
+++ b/plasma_framework/contracts/quasar/utils/TimelockedValue.sol
@@ -1,0 +1,57 @@
+pragma solidity 0.5.11;
+
+/**
+ * @notice Stores a value that can only be updated after a waiting period 
+ */
+library TimelockedValue {
+    uint64 constant public WAITING_PERIOD = 7 days;
+
+    /**
+     * @param previousValue The value prior to upgrade, which should remain the same until the waiting period completes
+     * @param updatedValue The value to use once the waiting period completes
+     * @param effectiveUpdateTime A timestamp for the end of the waiting period, when the updated value comes into effect
+     */
+    struct Params {
+        uint64 previousValue;
+        uint64 updatedValue;
+        uint128 effectiveUpdateTime;
+    }
+
+    function buildParams(uint64 initialValue)
+        internal
+        pure
+        returns (Params memory)
+    {
+        // Set the initial value far into the future
+        uint128 initialEffectiveUpdateTime = 2 ** 63;
+        return Params({
+            previousValue: initialValue,
+            updatedValue: initialValue,
+            effectiveUpdateTime: initialEffectiveUpdateTime
+        });
+    }
+
+    /**
+    * @notice Updates the value
+    * @dev The new value comes into effect once the waiting period completes
+    * @param newValue The new value
+    */
+    function updateValue(Params storage self, uint64 newValue) internal {
+        if (now >= self.effectiveUpdateTime) {
+            self.previousValue = self.updatedValue;
+        }
+        self.updatedValue = newValue;
+        self.effectiveUpdateTime = uint64(now) + WAITING_PERIOD;
+    }
+
+    /**
+    * @notice Returns the current value
+    */
+    function getValue(Params memory self) internal view returns (uint64) {
+        if (now < self.effectiveUpdateTime) {
+            return self.previousValue;
+        } else {
+            return self.updatedValue;
+        }
+    }
+}

--- a/plasma_framework/test/endToEndTests/QuasarExit.e2e.test.js
+++ b/plasma_framework/test/endToEndTests/QuasarExit.e2e.test.js
@@ -319,9 +319,6 @@ contract(
                                     const expectedReservedAmount = new BN(DEPOSIT_VALUE - this.quasarFeeEth);
                                     expect(ticketData.reservedAmount).to.be.bignumber.equal(expectedReservedAmount);
                                     expect(ticketData.token).to.be.equal(ETH);
-                                    expect(ticketData.bondValue).to.be.bignumber.equal(
-                                        new BN(this.dummyQuasarBondValue),
-                                    );
                                     expect(ticketData.isClaimed).to.be.false;
                                 });
 
@@ -1439,9 +1436,6 @@ contract(
                                         const expectedReservedAmount = new BN(DEPOSIT_VALUE - this.quasarFeeErc);
                                         expect(ticketData.reservedAmount).to.be.bignumber.equal(expectedReservedAmount);
                                         expect(ticketData.token).to.be.equal(this.erc20.address);
-                                        expect(ticketData.bondValue).to.be.bignumber.equal(
-                                            new BN(this.dummyQuasarBondValue),
-                                        );
                                         expect(ticketData.isClaimed).to.be.false;
                                     });
 


### PR DESCRIPTION
Some tweaks resulting from audit:
- Remove bondValue from the Ticket struct
- Change functions from public to external where possible
- Add ReentrancyGuard to QuasarPool functions
- Make safeBlockMargin a Timelocked value.
- The contract bytecode is very close to the EIP-170 0x6000 size limit. To be able to make the previous modifications, I've had to reduce the size of the `require` messages